### PR TITLE
Fixes #18: Updating repo link & corresponding commands in cloud9 setup script

### DIFF
--- a/cloud9-setup.sh
+++ b/cloud9-setup.sh
@@ -1,6 +1,6 @@
 sudo apt-get update
-sudo apt-get install -y ant openjdk-8-jdk; git clone https://github.com/loklak/loklak_server.git loklak_server
-cd loklak_server;
+sudo apt-get install -y ant openjdk-8-jdk; git clone https://github.com/fossasia/susi_server.git susi_server
+cd susi_server;
 sed -i.bak 's/^\(port.http=\).*/\180/'                conf/config.properties
 sed -i.bak 's/^\(port.https=\).*/\1443/'              conf/config.properties
 sed -i.bak 's/^\(upgradeInterval=\).*/\186400000000/' conf/config.properties


### PR DESCRIPTION
Fixes #18: Updating repo link & corresponding commands in cloud9 setup script

* Updated link to new `susi_server` repo
* Changed folder name & the corresponding command accordingly