### PR TITLE
remove theme 'susi' parameter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,1 @@
-theme: susi
+theme: 


### PR DESCRIPTION
if we're using own theme, we should leave theme blank.
the theme parameter should have a valid Github jekyll theme, or be blank