### PR TITLE
updated the dockerfile for susi deployment with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get upgrade -y
 RUN apt-get install -y git ant openjdk-8-jdk
 
 # clone the github repo
-RUN git clone https://github.com/loklak/loklak_server.git
-WORKDIR loklak_server
+RUN git clone https://github.com/fossasia/susi_server.git
+WORKDIR susi_server
 
 # compile
 RUN ant


### PR DESCRIPTION
updated the dockerfile for susi deployment with docker.
instead of cloning the susi_server it clones the loklak_server repo when building with docker.

Please merge this ASAP!

Fixes issue: https://github.com/fossasia/susi_server/issues/58