### PR TITLE
Adding support for untracked files in gh-pagesUpdater.sh

### DIFF
--- a/scripts/gh-pagesUpdater.sh
+++ b/scripts/gh-pagesUpdater.sh
@@ -24,7 +24,7 @@ cp -rf ../../docs ./
 cp -rf ../../README.md ./index.md
 
 # Adding everything
-git add .
+git add -A
 
 # Checking for staged changes
 git status --porcelain|grep "M"


### PR DESCRIPTION
Untracked files where ommitted and this caused the bot not to push back, added support for untracked files.
In this PR: I,
- Squashed all my commits
- Included support for the untracked files

I didn't reference an issue number because there is still no issue resent for this. And the tweak is simple.
@mariobehling pls review. Thankyou.