### PR TITLE
fixes #180: made regex simple accept any password with minimum 6 letters

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -13,8 +13,9 @@ host.url=http://localhost:4000
 users.public.signup=true
 
 # Regular expression for passwords (warning: has to be a valid java string, escape characters need to be double escaped e.g. \\d instead of \d
-users.password.regex=^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{6,64}$
-users.password.regex.tooltip=Enter a combination of atleast six characters, containing lower- and uppercase letters and numbers
+# Simple password:combination of at least six characters for the moment to get more users
+users.password.regex=^.{6,64}$
+users.password.regex.tooltip=Enter a combination of atleast six characters
 
 # Set all servlets requiring ADMIN BaseUserRole to be only accessible from localhost
 users.admin.localonly=true


### PR DESCRIPTION

Fixes issue #180 , addresses issue [#607](https://github.com/fossasia/susi_android/issues/607)(susi_android).

Changes: made strong password regex simple to accept any password with minimum 6 letters.


