### PR TITLE
API to return list of groups for  given models

### DIFF
--- a/src/ai/susi/SusiServer.java
+++ b/src/ai/susi/SusiServer.java
@@ -464,6 +464,7 @@ public class SusiServer {
                 SignUpService.class,
                 TopMenuService.class,
                 ExpertConvertJsonToTxtService.class,
+                GroupListService.class,
                 ExpertConvertTxtToJsonService.class,
                 ExpertGetJsonService.class,
                 ExpertGetTxtService.class,

--- a/src/ai/susi/server/api/cms/GroupListService.java
+++ b/src/ai/susi/server/api/cms/GroupListService.java
@@ -8,11 +8,14 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Created by dravit on 10/6/17.
+ * API to get list of groups for a given model.
+ * test locally at http://127.0.0.1:4000/cms/getgroups.json
  */
+
 public class GroupListService extends AbstractAPIHandler implements APIHandler {
     @Override
     public String getAPIPath() {
-        return null;
+        return "/cms/getgroups.json";
     }
 
     @Override

--- a/src/ai/susi/server/api/cms/GroupListService.java
+++ b/src/ai/susi/server/api/cms/GroupListService.java
@@ -1,10 +1,14 @@
 package ai.susi.server.api.cms;
 
+import ai.susi.DAO;
 import ai.susi.json.JsonObjectWithDefault;
 import ai.susi.server.*;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.FilenameFilter;
 
 /**
  * Created by dravit on 10/6/17.
@@ -29,7 +33,18 @@ public class GroupListService extends AbstractAPIHandler implements APIHandler {
     }
 
     @Override
-    public ServiceResponse serviceImpl(Query post, HttpServletResponse response, Authorization rights, JsonObjectWithDefault permissions) throws APIException {
-        return null;
+    public ServiceResponse serviceImpl(Query call, HttpServletResponse response, Authorization rights, JsonObjectWithDefault permissions) throws APIException {
+
+        String model_name = call.get("model", "general");
+        File model = new File(DAO.model_watch_dir, model_name);
+
+        String[] groups = model.list(new FilenameFilter() {
+            @Override
+            public boolean accept(File file, String s) {
+                return new File(file, s).isDirectory();
+            }
+        });
+        JSONArray groupsArray = new JSONArray(groups);
+        return new ServiceResponse(groupsArray);
     }
 }

--- a/src/ai/susi/server/api/cms/GroupListService.java
+++ b/src/ai/susi/server/api/cms/GroupListService.java
@@ -1,0 +1,32 @@
+package ai.susi.server.api.cms;
+
+import ai.susi.json.JsonObjectWithDefault;
+import ai.susi.server.*;
+import org.json.JSONObject;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Created by dravit on 10/6/17.
+ */
+public class GroupListService extends AbstractAPIHandler implements APIHandler {
+    @Override
+    public String getAPIPath() {
+        return null;
+    }
+
+    @Override
+    public BaseUserRole getMinimalBaseUserRole() {
+        return null;
+    }
+
+    @Override
+    public JSONObject getDefaultPermissions(BaseUserRole baseUserRole) {
+        return null;
+    }
+
+    @Override
+    public ServiceResponse serviceImpl(Query post, HttpServletResponse response, Authorization rights, JsonObjectWithDefault permissions) throws APIException {
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes issue #246 

Changes: Added API to extract all the groups for a given model. 
Test locally at http://127.0.0.1:4000/cms/getgroups.json
Screenshots for the change: 
![groups](https://user-images.githubusercontent.com/14837478/27001203-b8035554-4de1-11e7-8e25-4970fc2fd13c.png)
