### PR TITLE
Added historization when an expert is modified

### DIFF
--- a/src/ai/susi/server/api/cms/ModifyExpertService.java
+++ b/src/ai/susi/server/api/cms/ModifyExpertService.java
@@ -92,7 +92,7 @@ public class ModifyExpertService extends AbstractAPIHandler implements APIHandle
                             .call();
                     // and then commit the changes
                     git.commit()
-                            .setMessage("Modified:" + expert_name + "- Changes "+ commit_message)
+                            .setMessage(commit_message)
                             .call();
 
                 } catch (GitAPIException e) {

--- a/src/ai/susi/server/api/cms/ModifyExpertService.java
+++ b/src/ai/susi/server/api/cms/ModifyExpertService.java
@@ -53,17 +53,20 @@ public class ModifyExpertService extends AbstractAPIHandler implements APIHandle
         File expert = new File(language, expert_name + ".txt");
 
         String commit_message = call.get("changelog", null);
+
         if(commit_message==null){
             JSONObject error = new JSONObject();
             error.put("accepted", false);
             return new ServiceResponse(error);
         }
+
         // Checking for file existence
         if(!expert.exists()){
             JSONObject error = new JSONObject();
             error.put("accepted", false);
             return new ServiceResponse(error);
         }
+
         // Reading Content for expert
         String content = call.get("content", "");
         if(Objects.equals(content, "")){
@@ -71,6 +74,7 @@ public class ModifyExpertService extends AbstractAPIHandler implements APIHandle
             error.put("accepted", false);
             return new ServiceResponse(error);
         }
+
         // Writing to File
         try (FileWriter file = new FileWriter(expert)) {
             file.write(content);
@@ -81,6 +85,7 @@ public class ModifyExpertService extends AbstractAPIHandler implements APIHandle
             FileRepositoryBuilder builder = new FileRepositoryBuilder();
             Repository repository = null;
             try {
+
                 repository = builder.setGitDir((DAO.susi_skill_repo))
                         .readEnvironment() // scan environment GIT_* variables
                         .findGitDir() // scan up the file system tree
@@ -101,12 +106,11 @@ public class ModifyExpertService extends AbstractAPIHandler implements APIHandle
             } catch (IOException e) {
                 e.printStackTrace();
             }
-
             return new ServiceResponse(success);
         } catch (IOException e) {
             e.printStackTrace();
         }
         return null;
     }
-
+    
 }

--- a/src/ai/susi/server/api/cms/ModifyExpertService.java
+++ b/src/ai/susi/server/api/cms/ModifyExpertService.java
@@ -17,10 +17,11 @@ import java.util.Objects;
 
 /**
  * Created by chetankaushik on 07/06/17.
- * This Endpoint accepts 5 parameters. model,group,language,expert,content.
+ * This Endpoint accepts 5 parameters. model,group,language,expert,content, changelog.
+ * changelog is the commit message that you want to set for the versioning system.
  * before modifying an expert the expert must exist in the directory.
  * !IMPORTANT! --> Content must be URL Encoded
- * http://localhost:4000/cms/modifyExpert.json?model=general&group=knowledge&expert=testing&content=What is stock price of *%3F|What is stock price of *|stock price of *|* stock price of *%0A!console%3A%24l%24%0A{%0A "url"%3A"http%3A%2F%2Ffinance.google.com%2Ffinance%2Finfo%3Fclient%3Dig%26q%3DNASDAQ%3A%241%24"%2C%0A "path"%3A"%24.[0]"%0A}%0Aeol%0A
+ * http://localhost:4000/cms/modifyExpert.json?model=general&group=knowledge&expert=who&content=What%20is%20stock%20price%20of%20*%3F|What%20is%20stock%20price%20of%20*|stock%20price%20of%20*|*%20stock%20price%20of%20*%0A!console%3A%24l%24%0A{%0A%20%22url%22%3A%22http%3A%2F%2Ffinance.google.com%2Ffinance%2Finfo%3Fclient%3Dig%26q%3DNASDAQ%3A%241%24%22%2C%0A%20%22path%22%3A%22%24.[0]%22%0A}%0Aeol%0A&changelog=testing
  */
 public class ModifyExpertService extends AbstractAPIHandler implements APIHandler {
 

--- a/src/ai/susi/server/api/cms/ModifyExpertService.java
+++ b/src/ai/susi/server/api/cms/ModifyExpertService.java
@@ -52,7 +52,11 @@ public class ModifyExpertService extends AbstractAPIHandler implements APIHandle
         File expert = new File(language, expert_name + ".txt");
 
         String commit_message = call.get("changelog", null);
-
+        if(commit_message==null){
+            JSONObject error = new JSONObject();
+            error.put("accepted", false);
+            return new ServiceResponse(error);
+        }
         // Checking for file existence
         if(!expert.exists()){
             JSONObject error = new JSONObject();


### PR DESCRIPTION
This is in continuation of issue #242. I added an API endpoint to create a commit to the skill data repository when an expert is modified.
This fixes issue https://github.com/fossasia/susi_server/issues/272
Can be tested on:
http://localhost:4000/cms/modifyExpert.json?model=general&group=knowledge&expert=who&content=What%20is%20stock%20price%20of%20*%3F|What%20is%20stock%20price%20of%20*|stock%20price%20of%20*|*%20stock%20price%20of%20*%0A!console%3A%24l%24%0A{%0A%20%22url%22%3A%22http%3A%2F%2Ffinance.google.com%2Ffinance%2Finfo%3Fclient%3Dig%26q%3DNASDAQ%3A%241%24%22%2C%0A%20%22path%22%3A%22%24.[0]%22%0A}%0Aeol%0A&changelog=testing