### PR TITLE
Added Endpoint to get all languages for a group and model

### DIFF
--- a/src/ai/susi/SusiServer.java
+++ b/src/ai/susi/SusiServer.java
@@ -477,6 +477,7 @@ public class SusiServer {
                 LanguageListService.class,
                 ListUserSettings.class,
                 ListSkillService.class,
+                GetAllLanguages.class,
                 ExampleSkillService.class,
                 UserManagementService.class,
                 ChangeUserSettings.class,

--- a/src/ai/susi/server/api/cms/GetAllLanguages.java
+++ b/src/ai/susi/server/api/cms/GetAllLanguages.java
@@ -1,0 +1,46 @@
+package ai.susi.server.api.cms;
+
+import ai.susi.DAO;
+import ai.susi.json.JsonObjectWithDefault;
+import ai.susi.server.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.util.ArrayList;
+
+/**
+ * Created by chetankaushik on 24/06/17.
+ */
+public class GetAllLanguages  extends AbstractAPIHandler implements APIHandler {
+
+
+    private static final long serialVersionUID = -5176264536025896261L;
+
+    @Override
+    public BaseUserRole getMinimalBaseUserRole() { return BaseUserRole.ANONYMOUS; }
+
+    @Override
+    public JSONObject getDefaultPermissions(BaseUserRole baseUserRole) {
+        return null;
+    }
+
+    @Override
+    public String getAPIPath() {
+        return "/cms/getAllLanguages.json";
+    }
+
+    @Override
+    public ServiceResponse serviceImpl(Query call, HttpServletResponse response, Authorization rights, final JsonObjectWithDefault permissions) {
+
+        String model_name = call.get("model", "general");
+        File model = new File(DAO.model_watch_dir, model_name);
+        String group_name = call.get("group", "knowledge");
+        File group = new File(model, group_name);
+
+        String[] languages = group.list((current, name) -> new File(current, name).isDirectory());
+        JSONArray modelsArray = new JSONArray(languages);
+        return new ServiceResponse(modelsArray);
+    }
+}

--- a/src/ai/susi/server/api/cms/GetAllLanguages.java
+++ b/src/ai/susi/server/api/cms/GetAllLanguages.java
@@ -1,3 +1,4 @@
+
 package ai.susi.server.api.cms;
 
 import ai.susi.DAO;
@@ -12,6 +13,10 @@ import java.util.ArrayList;
 
 /**
  * Created by chetankaushik on 24/06/17.
+ * Adds API Endpoint to get all languages for a group.
+ * BASE ROLE Required is ANONYMOUS
+ * Accepts 2 GET parameters, Model Name and Group Name
+ * http://127.0.0.1:4000/cms/getAllLanguages.json?group=assistants
  */
 public class GetAllLanguages  extends AbstractAPIHandler implements APIHandler {
 

--- a/src/ai/susi/server/api/cms/GetAllLanguages.java
+++ b/src/ai/susi/server/api/cms/GetAllLanguages.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 public class GetAllLanguages  extends AbstractAPIHandler implements APIHandler {
 
 
-    private static final long serialVersionUID = -5176264536025896261L;
+    private static final long serialVersionUID = -7872551914189898030L;
 
     @Override
     public BaseUserRole getMinimalBaseUserRole() { return BaseUserRole.ANONYMOUS; }
@@ -40,7 +40,7 @@ public class GetAllLanguages  extends AbstractAPIHandler implements APIHandler {
         File group = new File(model, group_name);
 
         String[] languages = group.list((current, name) -> new File(current, name).isDirectory());
-        JSONArray modelsArray = new JSONArray(languages);
-        return new ServiceResponse(modelsArray);
+        JSONArray languagesArray = new JSONArray(languages);
+        return new ServiceResponse(languagesArray);
     }
 }

--- a/src/ai/susi/server/api/cms/GetAllLanguages.java
+++ b/src/ai/susi/server/api/cms/GetAllLanguages.java
@@ -1,3 +1,21 @@
+/**
+ * GetAllLanguages
+ * Created by chetankaushik on 24/06/17.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program in the file lgpl21.txt
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 package ai.susi.server.api.cms;
 


### PR DESCRIPTION
Fixes issue #313 
 Adds API Endpoint to get all languages for a group.
 BASE ROLE Required is ANONYMOUS
 Accepts 2 GET parameters, Model Name and Group Name
Can be tested locally on:
 http://127.0.0.1:4000/cms/getAllLanguages.json?group=assistants