### PR TITLE
Added Image in RSS, Also Added Short Description.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ assemble.dependsOn shadowJar
 
 repositories {
   mavenCentral()
+  maven { url 'https://github.com/broadbear/maven-repo/raw/master' }
+
 }
 
 dependencies {
@@ -59,6 +61,7 @@ dependencies {
   compile group: 'jfree', name: 'jfreechart', version: '1.+'
   compile 'org.eclipse.jgit:org.eclipse.jgit:4.6.1.201703071140-r'
   compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.+'
+  compile 'org.broadbear:link-preview:1.2'
   compile(project(':dependencies:public-transport-enabler:enabler')) {	}
 
 }
@@ -74,8 +77,8 @@ task start(type: JavaExec, dependsOn: classes) {
 }
 
 jacocoTestReport {
-    reports {
-        xml.enabled true
-        html.enabled false
-    }
+  reports {
+    xml.enabled true
+    html.enabled false
+  }
 }

--- a/src/ai/susi/server/api/susi/RSSReaderService.java
+++ b/src/ai/susi/server/api/susi/RSSReaderService.java
@@ -21,6 +21,8 @@ package ai.susi.server.api.susi;
 
 import java.util.List;
 
+import org.broadbear.link.preview.SourceContent;
+import org.broadbear.link.preview.TextCrawler;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -93,9 +95,11 @@ public class RSSReaderService extends AbstractAPIHandler implements APIHandler {
 			jsonObject.put("link", entry.getLink().toString());
 			jsonObject.put("uri", entry.getUri().toString());
 			jsonObject.put("guid", Integer.toString(entry.hashCode()));
+			SourceContent sourceContent = 	TextCrawler.scrape(entry.getUri(),3);
 			if (entry.getPublishedDate() != null) jsonObject.put("pubDate", entry.getPublishedDate().toString());
 			if (entry.getUpdatedDate() != null) jsonObject.put("updateDate", entry.getUpdatedDate().toString());
 			if (entry.getDescription() != null) jsonObject.put("description", entry.getDescription().getValue().toString());
+			if (sourceContent.getImages() != null) jsonObject.put("image", sourceContent.getImages().get(0));
 
 			jsonArray.put(i, jsonObject);
 

--- a/src/ai/susi/server/api/susi/RSSReaderService.java
+++ b/src/ai/susi/server/api/susi/RSSReaderService.java
@@ -100,6 +100,7 @@ public class RSSReaderService extends AbstractAPIHandler implements APIHandler {
 			if (entry.getUpdatedDate() != null) jsonObject.put("updateDate", entry.getUpdatedDate().toString());
 			if (entry.getDescription() != null) jsonObject.put("description", entry.getDescription().getValue().toString());
 			if (sourceContent.getImages() != null) jsonObject.put("image", sourceContent.getImages().get(0));
+			if (sourceContent.getDescription() != null) jsonObject.put("descriptionShort", sourceContent.getDescription());
 
 			jsonArray.put(i, jsonObject);
 


### PR DESCRIPTION
Partially Fixes issue #318 

Changes: 
Previously `description` was being sent as HTML, so there might some issues with clients in parsing it. I added a new JSON object called `descriptionShort` which scrapes the short description from a URL of the RSS feed. Also, I added a new parameter `image` which returns the first image of the URL.

`"data"`: [
    {
      `"image"`: "https://s3.reutersmedia.net/resources/r/?m=02&d=20170630&t=2&i=1191116778&w=&fh=545px&fw=&ll=&pl=&sq=&r=LYNXMPED5T0G5",
      `"link"`: "http://feeds.reuters.com/~r/reuters/INtopNews/~3/QlSkLOOjVOU/india-railways-steel-idINKBN19L0PA",
      `"guid"`: "1897129841",
`"title"`: "Exclusive: Indian Railways safety overhaul at risk due to rail shortage - documents",
     `"descriptionShort"`: "A planned $15 billion safety overhaul of India's ageing rail network is facing delays as the country's state steel company is unable to meet demand for new rails, according to two government documents seen by Reuters.",
}

