### PR TITLE
first step for skills rating

### DIFF
--- a/src/ai/susi/DAO.java
+++ b/src/ai/susi/DAO.java
@@ -188,8 +188,12 @@ public class DAO {
         group = new JsonTray(groups_per.toFile(), groups_vol.toFile(), 1000000);
         OS.protectPath(groups_per);
         OS.protectPath(groups_vol);
-        Path skillRating_per = settings_dir.resolve("skillRating.json");
-        Path skillRating_vol = settings_dir.resolve("skillRating_session.json");
+
+        /*Skill Rating storage*/
+        Path susi_skill_rating_dir = dataPath.resolve("skill_rating");
+        susi_skill_rating_dir.toFile().mkdirs();
+        Path skillRating_per = susi_skill_rating_dir.resolve("skillRating.json");
+        Path skillRating_vol = susi_skill_rating_dir.resolve("skillRating_session.json");
         skillRating = new JsonTray(skillRating_per.toFile(), skillRating_vol.toFile(), 1000000);
         OS.protectPath(skillRating_per);
         OS.protectPath(skillRating_vol);

--- a/src/ai/susi/DAO.java
+++ b/src/ai/susi/DAO.java
@@ -92,6 +92,7 @@ public class DAO {
     public  static JsonTray passwordreset;
     private static JsonFile login_keys;
     public static JsonTray group;
+    public static JsonTray skillRating;
 
 
     // built-in artificial intelligence
@@ -123,7 +124,7 @@ public class DAO {
         String susi_boilerplate_name = "susi_cognition_boilerplate.json";
         File susi_boilerplate_file = new File(susi_memory_dir, susi_boilerplate_name);
         if (!susi_boilerplate_file.exists()) Files.copy(new File(conf_dir, "susi/" + susi_boilerplate_name + ".example"), susi_boilerplate_file);
-        
+
         // initialize public and private keys
 		public_settings = new Settings(new File("data/settings/public.settings.json"));
 		File private_file = new File("data/settings/private.settings.json");
@@ -187,6 +188,11 @@ public class DAO {
         group = new JsonTray(groups_per.toFile(), groups_vol.toFile(), 1000000);
         OS.protectPath(groups_per);
         OS.protectPath(groups_vol);
+        Path skillRating_per = settings_dir.resolve("skillRating.json");
+        Path skillRating_vol = settings_dir.resolve("skillRating_session.json");
+        skillRating = new JsonTray(skillRating_per.toFile(), skillRating_vol.toFile(), 1000000);
+        OS.protectPath(skillRating_per);
+        OS.protectPath(skillRating_vol);
 
 
         Log.getLog().info("Initializing user roles");

--- a/src/ai/susi/SusiServer.java
+++ b/src/ai/susi/SusiServer.java
@@ -485,6 +485,7 @@ public class SusiServer {
                 ChangeUserSettings.class,
                 UserAccountPermissions.class,
                 JsonPathTestService.class,
+                RateSkillService.class,
                 DeleteSkillService.class,
                 ModifySkillService.class,
                 HistorySkillService.class,

--- a/src/ai/susi/server/api/cms/RateSkillService.java
+++ b/src/ai/susi/server/api/cms/RateSkillService.java
@@ -66,7 +66,7 @@ public class RateSkillService extends AbstractAPIHandler implements APIHandler {
                     JSONObject languageName = groupName.getJSONObject(language_name);
                     if (languageName.has(skill_name)) {
                         JSONObject skillName = languageName.getJSONObject(skill_name);
-                        skillName.put(skill_name, skillName.getInt(skill_name) + 1 + "");
+                        skillName.put(skill_rate, skillName.getInt(skill_name) + 1 + "");
                     } else {
                         languageName.put(skill_name, createRatingObject(skill_rate,skill_name));
                     }
@@ -89,9 +89,9 @@ public class RateSkillService extends AbstractAPIHandler implements APIHandler {
             groupName.put(language_name, languageName);
             JSONObject modelName = new JSONObject();
             modelName.put(group_name, groupName);
-            skillRating.put(model_name, modelName, rights.getIdentity().isPersistent());
+            skillRating.put(model_name, modelName, true);
         }
-        result.put("accepted", false);
+        result.put("accepted", true);
         return new ServiceResponse(result);
     }
    /* Utility function*/
@@ -99,7 +99,7 @@ public class RateSkillService extends AbstractAPIHandler implements APIHandler {
         JSONObject skillName = new JSONObject();
         skillName.put("positive", "0");
         skillName.put("negative", "0");
-        skillName.put(skill_name, skillName.getInt(skill_rate) + 1 + "");
+        skillName.put(skill_rate, skillName.getInt(skill_rate) + 1 + "");
         return skillName;
     }
 }

--- a/src/ai/susi/server/api/cms/RateSkillService.java
+++ b/src/ai/susi/server/api/cms/RateSkillService.java
@@ -68,45 +68,38 @@ public class RateSkillService extends AbstractAPIHandler implements APIHandler {
                         JSONObject skillName = languageName.getJSONObject(skill_name);
                         skillName.put(skill_name, skillName.getInt(skill_name) + 1 + "");
                     } else {
-                        JSONObject skillName = new JSONObject();
-                        skillName.put("positive", "0");
-                        skillName.put("negative", "0");
-                        skillName.put(skill_name, skillName.getInt(skill_rate) + 1 + "");
-                        languageName.put(skill_name, skillName);
+                        languageName.put(skill_name, createRatingObject(skill_rate,skill_name));
                     }
                 } else {
-                    JSONObject skillName = new JSONObject();
-                    skillName.put("positive", "0");
-                    skillName.put("negative", "0");
-                    skillName.put(skill_name, skillName.getInt(skill_rate) + 1 + "");
                     JSONObject languageName = new JSONObject();
-                    languageName.put(skill_name, skillName);
+                    languageName.put(skill_name, createRatingObject(skill_rate,skill_name));
                     groupName.put(language_name, languageName);
                 }
             } else {
-                JSONObject skillName = new JSONObject();
-                skillName.put("positive", "0");
-                skillName.put("negative", "0");
-                skillName.put(skill_name, skillName.getInt(skill_rate) + 1 + "");
                 JSONObject languageName = new JSONObject();
-                languageName.put(skill_name, skillName);
+                languageName.put(skill_name, createRatingObject(skill_rate,skill_name));
                 JSONObject groupName = new JSONObject();
                 groupName.put(language_name, languageName);
                 modelName.put(group_name, groupName);
             }
         } else {
-            JSONObject skillName = new JSONObject();
-            skillName.put("positive", "0");
-            skillName.put("negative", "0");
-            skillName.put(skill_name, skillName.getInt(skill_rate) + 1 + "");
             JSONObject languageName = new JSONObject();
-            languageName.put(skill_name, skillName);
+            languageName.put(skill_name, createRatingObject(skill_rate,skill_name));
             JSONObject groupName = new JSONObject();
             groupName.put(language_name, languageName);
             JSONObject modelName = new JSONObject();
             modelName.put(group_name, groupName);
             skillRating.put(model_name, modelName, rights.getIdentity().isPersistent());
         }
+        result.put("accepted", false);
         return new ServiceResponse(result);
+    }
+   /* Utility function*/
+    public JSONObject createRatingObject(String skill_rate, String skill_name) {
+        JSONObject skillName = new JSONObject();
+        skillName.put("positive", "0");
+        skillName.put("negative", "0");
+        skillName.put(skill_name, skillName.getInt(skill_rate) + 1 + "");
+        return skillName;
     }
 }

--- a/src/ai/susi/server/api/cms/RateSkillService.java
+++ b/src/ai/susi/server/api/cms/RateSkillService.java
@@ -66,14 +66,23 @@ public class RateSkillService extends AbstractAPIHandler implements APIHandler {
                     JSONObject languageName = groupName.getJSONObject(language_name);
                     if (languageName.has(skill_name)) {
                         JSONObject skillName = languageName.getJSONObject(skill_name);
-                        skillName.put(skill_rate, skillName.getInt(skill_name) + 1 + "");
+                        skillName.put(skill_rate, skillName.getInt(skill_rate) + 1 + "");
+                        languageName.put(skill_name, skillName);
+                        groupName.put(language_name, languageName);
+                        modelName.put(group_name, groupName);
+                        skillRating.put(model_name, modelName, true);
                     } else {
                         languageName.put(skill_name, createRatingObject(skill_rate,skill_name));
+                        groupName.put(language_name, languageName);
+                        modelName.put(group_name, groupName);
+                        skillRating.put(model_name, modelName, true);
                     }
                 } else {
                     JSONObject languageName = new JSONObject();
                     languageName.put(skill_name, createRatingObject(skill_rate,skill_name));
                     groupName.put(language_name, languageName);
+                    modelName.put(group_name, groupName);
+                    skillRating.put(model_name, modelName, true);
                 }
             } else {
                 JSONObject languageName = new JSONObject();
@@ -81,6 +90,7 @@ public class RateSkillService extends AbstractAPIHandler implements APIHandler {
                 JSONObject groupName = new JSONObject();
                 groupName.put(language_name, languageName);
                 modelName.put(group_name, groupName);
+                skillRating.put(model_name, modelName, true);
             }
         } else {
             JSONObject languageName = new JSONObject();

--- a/src/ai/susi/server/api/cms/RateSkillService.java
+++ b/src/ai/susi/server/api/cms/RateSkillService.java
@@ -1,5 +1,24 @@
 package ai.susi.server.api.cms;
 
+/**
+ *  RateSkillService
+ *  Copyright by Saurabh Jain, @Saurabhjn76
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program in the file lgpl21.txt
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import ai.susi.DAO;
 import ai.susi.json.JsonObjectWithDefault;
 import ai.susi.json.JsonTray;
@@ -11,16 +30,15 @@ import java.io.File;
 
 
 /**
- * Created by saurabhjn76 .
- * This Endpoint accepts 5 parameters. model,group,language,skill,content, rating.
- * rating can be postive or negative
+ * This Endpoint accepts 5 parameters. model,group,language,skill,rating.
+ * rating can be positive or negative
  * before rating a skill the skill must exist in the directory.
  * http://localhost:4000/cms/rateSkill.json?model=general&group=knowledge&skill=who&rating=positive
  */
 public class RateSkillService extends AbstractAPIHandler implements APIHandler {
 
 
-    private static final long serialVersionUID = -4437528781864678779L;
+    private static final long serialVersionUID = 7947060716231250102L;
 
     @Override
     public BaseUserRole getMinimalBaseUserRole() {
@@ -58,12 +76,15 @@ public class RateSkillService extends AbstractAPIHandler implements APIHandler {
 
         }
         JsonTray skillRating = DAO.skillRating;
+        JSONObject modelName = new JSONObject();
+        JSONObject groupName = new JSONObject();
+        JSONObject languageName = new JSONObject();
         if (skillRating.has(model_name)) {
-            JSONObject modelName = skillRating.getJSONObject(model_name);
+            modelName = skillRating.getJSONObject(model_name);
             if (modelName.has(group_name)) {
-                JSONObject groupName = modelName.getJSONObject(group_name);
+                groupName = modelName.getJSONObject(group_name);
                 if (groupName.has(language_name)) {
-                    JSONObject languageName = groupName.getJSONObject(language_name);
+                    languageName = groupName.getJSONObject(language_name);
                     if (languageName.has(skill_name)) {
                         JSONObject skillName = languageName.getJSONObject(skill_name);
                         skillName.put(skill_rate, skillName.getInt(skill_rate) + 1 + "");
@@ -71,45 +92,31 @@ public class RateSkillService extends AbstractAPIHandler implements APIHandler {
                         groupName.put(language_name, languageName);
                         modelName.put(group_name, groupName);
                         skillRating.put(model_name, modelName, true);
-                    } else {
-                        languageName.put(skill_name, createRatingObject(skill_rate,skill_name));
-                        groupName.put(language_name, languageName);
-                        modelName.put(group_name, groupName);
-                        skillRating.put(model_name, modelName, true);
+                        result.put("accepted", true);
+                        result.put("message", "Skill ratings updated");
+                        return new ServiceResponse(result);
                     }
-                } else {
-                    JSONObject languageName = new JSONObject();
-                    languageName.put(skill_name, createRatingObject(skill_rate,skill_name));
-                    groupName.put(language_name, languageName);
-                    modelName.put(group_name, groupName);
-                    skillRating.put(model_name, modelName, true);
                 }
-            } else {
-                JSONObject languageName = new JSONObject();
-                languageName.put(skill_name, createRatingObject(skill_rate,skill_name));
-                JSONObject groupName = new JSONObject();
-                groupName.put(language_name, languageName);
-                modelName.put(group_name, groupName);
-                skillRating.put(model_name, modelName, true);
             }
-        } else {
-            JSONObject languageName = new JSONObject();
-            languageName.put(skill_name, createRatingObject(skill_rate,skill_name));
-            JSONObject groupName = new JSONObject();
-            groupName.put(language_name, languageName);
-            JSONObject modelName = new JSONObject();
-            modelName.put(group_name, groupName);
-            skillRating.put(model_name, modelName, true);
         }
+        languageName.put(skill_name, createRatingObject(skill_rate));
+        groupName.put(language_name, languageName);
+        modelName.put(group_name, groupName);
+        skillRating.put(model_name, modelName, true);
         result.put("accepted", true);
+        result.put("message", "Skill ratings added");
         return new ServiceResponse(result);
+
     }
-   /* Utility function*/
-    public JSONObject createRatingObject(String skill_rate, String skill_name) {
+
+    /* Utility function*/
+    public JSONObject createRatingObject(String skill_rate) {
         JSONObject skillName = new JSONObject();
         skillName.put("positive", "0");
         skillName.put("negative", "0");
         skillName.put(skill_rate, skillName.getInt(skill_rate) + 1 + "");
         return skillName;
     }
+
+
 }

--- a/src/ai/susi/server/api/cms/RateSkillService.java
+++ b/src/ai/susi/server/api/cms/RateSkillService.java
@@ -1,0 +1,112 @@
+package ai.susi.server.api.cms;
+
+import ai.susi.DAO;
+import ai.susi.json.JsonObjectWithDefault;
+import ai.susi.json.JsonTray;
+import ai.susi.server.*;
+import org.json.JSONObject;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+
+
+/**
+ * Created by saurabhjn76 .
+ * This Endpoint accepts 5 parameters. model,group,language,skill,content, rating.
+ * rating can be postive or negative
+ * before rating a skill the skill must exist in the directory.
+ * http://localhost:4000/cms/rateSkill.json?model=general&group=knowledge&skill=who&rating=positive
+ */
+public class RateSkillService extends AbstractAPIHandler implements APIHandler {
+
+
+    private static final long serialVersionUID = -4437528781864678779L;
+
+    @Override
+    public BaseUserRole getMinimalBaseUserRole() {
+        return BaseUserRole.ANONYMOUS;
+    }
+
+    @Override
+    public JSONObject getDefaultPermissions(BaseUserRole baseUserRole) {
+        return null;
+    }
+
+    @Override
+    public String getAPIPath() {
+        return "/cms/rateSkill.json";
+    }
+
+    @Override
+    public ServiceResponse serviceImpl(Query call, HttpServletResponse response, Authorization rights, final JsonObjectWithDefault permissions) {
+
+        String model_name = call.get("model", "general");
+        File model = new File(DAO.model_watch_dir, model_name);
+        String group_name = call.get("group", "knowledge");
+        File group = new File(model, group_name);
+        String language_name = call.get("language", "en");
+        File language = new File(group, language_name);
+        String skill_name = call.get("skill", null);
+        File skill = new File(language, skill_name + ".txt");
+        String skill_rate = call.get("rating", null);
+
+        JSONObject result = new JSONObject();
+        result.put("accepted", false);
+        if (!skill.exists()) {
+            result.put("message", "skill does not exist");
+            return new ServiceResponse(result);
+
+        }
+        JsonTray skillRating = DAO.skillRating;
+        if (skillRating.has(model_name)) {
+            JSONObject modelName = skillRating.getJSONObject(model_name);
+            if (modelName.has(group_name)) {
+                JSONObject groupName = modelName.getJSONObject(group_name);
+                if (groupName.has(language_name)) {
+                    JSONObject languageName = groupName.getJSONObject(language_name);
+                    if (languageName.has(skill_name)) {
+                        JSONObject skillName = languageName.getJSONObject(skill_name);
+                        skillName.put(skill_name, skillName.getInt(skill_name) + 1 + "");
+                    } else {
+                        JSONObject skillName = new JSONObject();
+                        skillName.put("positive", "0");
+                        skillName.put("negative", "0");
+                        skillName.put(skill_name, skillName.getInt(skill_rate) + 1 + "");
+                        languageName.put(skill_name, skillName);
+                    }
+                } else {
+                    JSONObject skillName = new JSONObject();
+                    skillName.put("positive", "0");
+                    skillName.put("negative", "0");
+                    skillName.put(skill_name, skillName.getInt(skill_rate) + 1 + "");
+                    JSONObject languageName = new JSONObject();
+                    languageName.put(skill_name, skillName);
+                    groupName.put(language_name, languageName);
+                }
+            } else {
+                JSONObject skillName = new JSONObject();
+                skillName.put("positive", "0");
+                skillName.put("negative", "0");
+                skillName.put(skill_name, skillName.getInt(skill_rate) + 1 + "");
+                JSONObject languageName = new JSONObject();
+                languageName.put(skill_name, skillName);
+                JSONObject groupName = new JSONObject();
+                groupName.put(language_name, languageName);
+                modelName.put(group_name, groupName);
+            }
+        } else {
+            JSONObject skillName = new JSONObject();
+            skillName.put("positive", "0");
+            skillName.put("negative", "0");
+            skillName.put(skill_name, skillName.getInt(skill_rate) + 1 + "");
+            JSONObject languageName = new JSONObject();
+            languageName.put(skill_name, skillName);
+            JSONObject groupName = new JSONObject();
+            groupName.put(language_name, languageName);
+            JSONObject modelName = new JSONObject();
+            modelName.put(group_name, groupName);
+            skillRating.put(model_name, modelName, rights.getIdentity().isPersistent());
+        }
+        return new ServiceResponse(result);
+    }
+}


### PR DESCRIPTION
Fixes issue #328 

Skillrating.json file gets generated at `susi_server/data/skill_rating`.
The current base user role is Anonymous.
 This Endpoint accepts 5 parameters. `{model,group,language,skill,rating.}`
 The rating can be positive or negative.
 Before rating a skill, skill must exist in the directory.
it can be tested at 
http://localhost:4000/cms/rateSkill.json?model=general&group=knowledge&skill=who&rating=positive


Changes: adding skillRating.json to store the likes and dislikes, added endpoint to write in file

Screenshots for the change: 
SkillRating file structure 
```
{"general": {
  "assistants": {"en": {
    "language_translation": {
      "negative": "1",
      "positive": "0"
    },
    "websearch": {
      "negative": "1",
      "positive": "0"
    }
  }},
  "smalltalk": {"en": {"aboutsusi": {
    "negative": "0",
    "positive": "1"
  }}},
  "knowledge": {"en": {
    "atomic": {
      "negative": "1",
      "positive": "0"
    },
    "who": {
      "negative": "2",
      "positive": "4"
    }
  }}
}}
```
![image](https://user-images.githubusercontent.com/9781788/27959816-94c32aa4-6346-11e7-9176-f7fe8c492f44.png)

![image](https://user-images.githubusercontent.com/9781788/27946129-e92c6490-630d-11e7-817f-23b68e8093b0.png)
