### PR TITLE
removed .gitfiles from listing skill api

### DIFF
--- a/src/ai/susi/server/api/cms/ListSkillService.java
+++ b/src/ai/susi/server/api/cms/ListSkillService.java
@@ -60,7 +60,7 @@ public class ListSkillService extends AbstractAPIHandler implements APIHandler {
         File[] filesInFolder = folder.listFiles();
         if (filesInFolder != null) {
             for (final File fileEntry : filesInFolder) {
-                if (!fileEntry.isDirectory()) {
+                if (!fileEntry.isDirectory() && !fileEntry.getName().startsWith(".")) {
                     fileList.add(fileEntry.getName()+"");
                 }
             }


### PR DESCRIPTION
Fixes issue #375 

Changes: added filename filter starting with '.'

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/9781788/28242070-48f5756c-69bf-11e7-9da5-da7f80ddd07a.png)
