### PR TITLE
added skill format details

### DIFF
--- a/src/ai/susi/mind/SusiMind.java
+++ b/src/ai/susi/mind/SusiMind.java
@@ -260,8 +260,8 @@ public class SusiMind {
                     this.authorsUrl.put(intent.getSkill(), json.getString("author_ur;"));
                 if(json.has("developer_privacy_policy"))
                     this.devloperPrivacyPolicies.put(intent.getSkill(), json.getString("developer_privacy_policy"));
-                if(json.has("term_of_use"))
-                    this.termsOfUse.put(intent.getSkill(), json.getString("term_of_use"));
+                if(json.has("terms_of_use"))
+                    this.termsOfUse.put(intent.getSkill(), json.getString("terms_of_use"));
                 if(json.has("dynamic_content"))
                     this.dynamicContent.put(intent.getSkill(), json.getBoolean("dynamic_content"));
                 //if (intent.getExample() != null && intent.getExpect() != null) {}

--- a/src/ai/susi/mind/SusiMind.java
+++ b/src/ai/susi/mind/SusiMind.java
@@ -64,6 +64,7 @@ public class SusiMind {
     private final Map<String, String> authorsUrl; // a map from skill path to skill authorsURL
     private final Map<String, String> devloperPrivacyPolicies; // a map from skill path to devloper Privacy Policy
     private final Map<String, String> termsOfUse; // a map from skill path to skill termsOfUse
+    private final Map<String,Boolean> dynamicContent; // a map from skill path and dynamic Content
 
 
     public SusiMind(File memorypath, File... watchpaths) {
@@ -86,6 +87,7 @@ public class SusiMind {
         this.skillNames = new TreeMap<>();
         this.devloperPrivacyPolicies =new TreeMap<>();
         this.termsOfUse = new TreeMap<>();
+        this.dynamicContent = new TreeMap<>();
         // learn all available intents
         try {observe();} catch (IOException e) {
             e.printStackTrace();
@@ -137,6 +139,10 @@ public class SusiMind {
 
     public Map<String, String> getTermsOfUse() {
         return this.termsOfUse;
+    }
+
+    public Map<String, Boolean> getDynamicContent() {
+        return this.dynamicContent;
     }
 
     public SusiMind observe() throws IOException {
@@ -256,6 +262,8 @@ public class SusiMind {
                     this.devloperPrivacyPolicies.put(intent.getSkill(), json.getString("developer_privacy_policy"));
                 if(json.has("term_of_use"))
                     this.termsOfUse.put(intent.getSkill(), json.getString("term_of_use"));
+                if(json.has("dynamic_content"))
+                    this.dynamicContent.put(intent.getSkill(), json.getBoolean("dynamic_content"));
                 //if (intent.getExample() != null && intent.getExpect() != null) {}
             });
         });

--- a/src/ai/susi/mind/SusiMind.java
+++ b/src/ai/susi/mind/SusiMind.java
@@ -59,7 +59,13 @@ public class SusiMind {
     private final Map<File, Long> observations; // a mapping of mind memory files to the time when the file was read the last time
     private final SusiReader reader; // responsible to understand written communication
     private final SusiMemory memories; // conversation logs are memories
-    
+    private final Map<String, String> skillNames; // a map from skill path to skill names
+    private final Map<String, String> authors; // a map from skill path to skill authors
+    private final Map<String, String> authorsUrl; // a map from skill path to skill authorsURL
+    private final Map<String, String> devloperPrivacyPolicies; // a map from skill path to devloper Privacy Policy
+    private final Map<String, String> termsOfUse; // a map from skill path to skill termsOfUse
+
+
     public SusiMind(File memorypath, File... watchpaths) {
         // initialize class objects
         this.watchpaths = watchpaths;
@@ -75,6 +81,11 @@ public class SusiMind {
         this.skillexamples = new TreeMap<>();
         this.skillDescriptions = new TreeMap<>();
         this.skillImage = new TreeMap<>();
+        this.authors = new TreeMap<>();
+        this.authorsUrl = new TreeMap<>();
+        this.skillNames = new TreeMap<>();
+        this.devloperPrivacyPolicies =new TreeMap<>();
+        this.termsOfUse = new TreeMap<>();
         // learn all available intents
         try {observe();} catch (IOException e) {
             e.printStackTrace();
@@ -107,7 +118,27 @@ public class SusiMind {
     public  Map<String, Set<String>> getSkillImage() {
         return this.skillImage;
     }
-    
+
+    public Map<String, String> getAuthors() {
+        return this.authors;
+    }
+
+    public Map<String, String> getAuthorsUrl() {
+        return this.authorsUrl;
+    }
+
+    public Map<String, String> getDevloperPrivacyPolicies() {
+        return this.devloperPrivacyPolicies;
+    }
+
+    public Map<String, String> getSkillNames() {
+        return this.skillNames;
+    }
+
+    public Map<String, String> getTermsOfUse() {
+        return this.termsOfUse;
+    }
+
     public SusiMind observe() throws IOException {
         for (int i = 0; i < watchpaths.length; i++) {
             observe(watchpaths[i]);
@@ -214,6 +245,17 @@ public class SusiMind {
                         }
                     image.add(intent.getImage());
                 }
+                // adding skill meta data
+                if(json.has("skill_name"))
+                    this.skillNames.put(intent.getSkill(), json.getString("skill_name"));
+                if(json.has("author"))
+                    this.authors.put(intent.getSkill(), json.getString("author"));
+                if(json.has("author_url"))
+                    this.authorsUrl.put(intent.getSkill(), json.getString("author_ur;"));
+                if(json.has("developer_privacy_policy"))
+                    this.devloperPrivacyPolicies.put(intent.getSkill(), json.getString("developer_privacy_policy"));
+                if(json.has("term_of_use"))
+                    this.termsOfUse.put(intent.getSkill(), json.getString("term_of_use"));
                 //if (intent.getExample() != null && intent.getExpect() != null) {}
             });
         });

--- a/src/ai/susi/mind/SusiSkill.java
+++ b/src/ai/susi/mind/SusiSkill.java
@@ -62,7 +62,7 @@ public class SusiSkill {
         json.put("intents", intents);
         String lastLine = "", line = "";
         String bang_phrases = "", bang_type = "", bang_term = ""; StringBuilder bang_bag = new StringBuilder();
-        String example = "", expect = "", description="", image="";
+        String example = "", expect = "", description="", image="", skillName="", authorName= "", authorURL = "", developerPrivacyPolicy = "", termOfUse="";
         boolean prior = false;
         try {readloop: while ((line = br.readLine()) != null) {
             line = line.trim();
@@ -176,9 +176,36 @@ public class SusiSkill {
             
             // read metadata
             if (line.startsWith("::")) {
+                int thenpos=-1;
                 line = line.toLowerCase();
                 if (line.startsWith("::minor")) prior = false;
                 if (line.startsWith("::prior")) prior = true;
+                if (line.startsWith("::name") && (thenpos = line.indexOf(' ')) > 0) {
+                    skillName = line.substring(thenpos + 1).trim();
+                    if(skillName.length() > 0)
+                        json.put("skill_name",skillName);
+                }
+                if (line.startsWith("::author") && (thenpos = line.indexOf(' ')) > 0) {
+                   authorName = line.substring(thenpos + 1).trim();
+                    if(authorName.length() > 0)
+                        json.put("author",authorName);
+                }
+                if (line.startsWith("::author_url") && (thenpos = line.indexOf(' ')) > 0) {
+                    authorURL = line.substring(thenpos + 1).trim();
+                    if(authorURL.length() > 0)
+                        json.put("author_url",authorURL);
+                }
+                if (line.startsWith("::developer_privacy_policy") && (thenpos = line.indexOf(' ')) > 0) {
+                    developerPrivacyPolicy = line.substring(thenpos + 1).trim();
+                    if(developerPrivacyPolicy.length() > 0)
+                        json.put("developer_privacy_policy",developerPrivacyPolicy);
+                }
+                if (line.startsWith("::term_of_use") && (thenpos = line.indexOf(' ')) > 0) {
+                    termOfUse = line.substring(thenpos + 1).trim();
+                    if(termOfUse.length() > 0)
+                        json.put("term_of_use ",termOfUse);
+                }
+
                 lastLine = ""; example = ""; expect = ""; description = ""; image = "";
                 continue readloop;
             }

--- a/src/ai/susi/mind/SusiSkill.java
+++ b/src/ai/susi/mind/SusiSkill.java
@@ -63,7 +63,7 @@ public class SusiSkill {
         String lastLine = "", line = "";
         String bang_phrases = "", bang_type = "", bang_term = ""; StringBuilder bang_bag = new StringBuilder();
         String example = "", expect = "", description="", image="", skillName="", authorName= "", authorURL = "", developerPrivacyPolicy = "", termOfUse="";
-        boolean prior = false;
+        boolean prior = false, dynamicContent = false;
         try {readloop: while ((line = br.readLine()) != null) {
             line = line.trim();
             
@@ -204,6 +204,10 @@ public class SusiSkill {
                     termOfUse = line.substring(thenpos + 1).trim();
                     if(termOfUse.length() > 0)
                         json.put("term_of_use ",termOfUse);
+                }
+                if (line.startsWith("::dynamic_content") && (thenpos = line.indexOf(' ')) > 0) {
+                    if (line.substring(thenpos + 1).trim().equalsIgnoreCase("yes")) dynamicContent=true;
+                    json.put("dynamic_content",dynamicContent);
                 }
 
                 lastLine = ""; example = ""; expect = ""; description = ""; image = "";

--- a/src/ai/susi/mind/SusiSkill.java
+++ b/src/ai/susi/mind/SusiSkill.java
@@ -62,7 +62,7 @@ public class SusiSkill {
         json.put("intents", intents);
         String lastLine = "", line = "";
         String bang_phrases = "", bang_type = "", bang_term = ""; StringBuilder bang_bag = new StringBuilder();
-        String example = "", expect = "", description="", image="", skillName="", authorName= "", authorURL = "", developerPrivacyPolicy = "", termOfUse="";
+        String example = "", expect = "", description="", image="", skillName="", authorName= "", authorURL = "", developerPrivacyPolicy = "", termsOfUse="";
         boolean prior = false, dynamicContent = false;
         try {readloop: while ((line = br.readLine()) != null) {
             line = line.trim();
@@ -200,10 +200,10 @@ public class SusiSkill {
                     if(developerPrivacyPolicy.length() > 0)
                         json.put("developer_privacy_policy",developerPrivacyPolicy);
                 }
-                if (line.startsWith("::term_of_use") && (thenpos = line.indexOf(' ')) > 0) {
-                    termOfUse = line.substring(thenpos + 1).trim();
-                    if(termOfUse.length() > 0)
-                        json.put("term_of_use ",termOfUse);
+                if (line.startsWith("::terms_of_use") && (thenpos = line.indexOf(' ')) > 0) {
+                    termsOfUse = line.substring(thenpos + 1).trim();
+                    if(termsOfUse.length() > 0)
+                        json.put("terms_of_use ",termsOfUse);
                 }
                 if (line.startsWith("::dynamic_content") && (thenpos = line.indexOf(' ')) > 0) {
                     if (line.substring(thenpos + 1).trim().equalsIgnoreCase("yes")) dynamicContent=true;


### PR DESCRIPTION
Fixes issue #424 

Changes: added format for the skill as discussed in [https://github.com/fossasia/susi_skill_data/issues/254](https://github.com/fossasia/susi_skill_data/issues/254).
```
::name <Skill_name>
::author <author_name>
::author_url <author_url>
::description <description> 
::dynamic_content <Yes/No>
::developer_privacy_policy <link>
::image <image_url>
::term_of_use <link>
#Intent
User query1|query2|quer3....
!example:<The question that should be shown in public skill displays>
!expect:<The answer expected for the above example>
Answer for the user query
```


Screenshots for the change: N/A
