### PR TITLE
Fixes #429 - Improve map action response

### DIFF
--- a/conf/susi/en_0020_console.json
+++ b/conf/susi/en_0020_console.json
@@ -24,6 +24,14 @@
       "path":"$.data",
       "license":"Copyright by GeoNames"
     },
+    "location-info":{
+      "example":"http://127.0.0.1:4000/susi/console.json?q=%22SELECT%20*%20FROM%20location-info%20WHERE%20query=%27london%27;%22",
+      "url":"https://en.wikipedia.org/w/api.php?action=opensearch&limit=1&format=json&search=",
+      "test":"london",
+      "parser":"json",
+      "path":"$.[2]",
+      "license":"Copyright by Wikipedia, https://wikimediafoundation.org/wiki/Terms_of_Use/en"
+    },
     "yacy":{
       "example":"http://127.0.0.1:4000/susi/console.json?q=%22SELECT%20title,%20link%20FROM%20yacy%20WHERE%20query=%27java%27;%22",
       "url":"http://yacy.searchlab.eu/solr/select?wt=yjson&q=",

--- a/conf/susi/en_0200_facts_knowledge.json
+++ b/conf/susi/en_0200_facts_knowledge.json
@@ -10,10 +10,11 @@
       {"type":"regex", "expression":"please describe (?:(?:a )*)(.*)"},
       {"type":"regex", "expression":"please explain (?:(?:a )*)(.*)"}
     ],
-    "process":[ {"type":"console", "expression":"SELECT place[0] AS place, population, location[0] AS lon, location[1] AS lat FROM locations WHERE query='$1$';"}],
+    "process":[ {"type":"console", "expression":"SELECT place[0] AS place, location[0] AS lon, location[1] AS lat FROM locations WHERE query='$1$';"},
+                {"type":"console", "expression":"SELECT object AS locationInfo FROM location-info WHERE query='$1$';"}],
     "actions":[
       {"type":"answer", "select":"random",
-       "phrases":["$place$ is a place with a population of $population$"]
+       "phrases":["$locationInfo$"]
       },
       {"type":"anchor", "link":"https://www.openstreetmap.org/#map=13/$lat$/$lon$", "text":"Link to Openstreetmap: $place$"},
       {"type":"map", "latitude":"$lat$", "longitude":"$lon$", "zoom":"13"}


### PR DESCRIPTION
Fixes issue #429 

**Changes:**
 - Added additional query from wikipedia api to get information about the location
 - `https://en.wikipedia.org/w/api.php?action=opensearch&limit=1&format=json&search=$query$` - This is the endpoint being used to fetch info about the location

**Screenshots for the change:** 

```
"actions": [
      {
        "type": "answer",
        "language": "en",
        "expression": "London  is the capital and most populous city of England and the United Kingdom."
      },
      {
        "type": "anchor",
        "link": "https://www.openstreetmap.org/#map=13/51.51279067225417/-0.09184009399817228",
        "text": "Link to Openstreetmap: City of London",
        "language": "en"
      },
      {
        "type": "map",
        "latitude": "51.51279067225417",
        "longitude": "-0.09184009399817228",
        "zoom": "13",
        "language": "en"
      }
    ],
```

@dynamitechetan @saurabhjn76 @DravitLochan @Orbiter @chiragw15 Please review