### PR TITLE
Fixes #429 - Changed anchor text to Here is a map for map action responses

### DIFF
--- a/conf/susi/en_0200_facts_knowledge.json
+++ b/conf/susi/en_0200_facts_knowledge.json
@@ -10,13 +10,13 @@
       {"type":"regex", "expression":"please describe (?:(?:a )*)(.*)"},
       {"type":"regex", "expression":"please explain (?:(?:a )*)(.*)"}
     ],
-    "process":[ {"type":"console", "expression":"SELECT place[0] AS place, location[0] AS lon, location[1] AS lat FROM locations WHERE query='$1$';"},
+    "process":[ {"type":"console", "expression":"SELECT location[0] AS lon, location[1] AS lat FROM locations WHERE query='$1$';"},
                 {"type":"console", "expression":"SELECT object AS locationInfo FROM location-info WHERE query='$1$';"}],
     "actions":[
       {"type":"answer", "select":"random",
        "phrases":["$locationInfo$"]
       },
-      {"type":"anchor", "link":"https://www.openstreetmap.org/#map=13/$lat$/$lon$", "text":"Link to Openstreetmap: $place$"},
+      {"type":"anchor", "link":"https://www.openstreetmap.org/#map=13/$lat$/$lon$", "text":"Here is a map"},
       {"type":"map", "latitude":"$lat$", "longitude":"$lon$", "zoom":"13"}
     ]
   }, {


### PR DESCRIPTION
Fixes issue #429 

**Changes:**
 - Changed the anchor text to `Here is a map` instead of 'Link to Openstreet Maps:...`

**Screenshots for the change:** 

![m](https://user-images.githubusercontent.com/13276887/29014361-49c0a332-7b66-11e7-9340-1308d0cd47a9.png)


```
"actions": [
      {
        "type": "answer",
        "language": "en",
        "expression": "London  is the capital and most populous city of England and the United Kingdom."
      },
      {
        "type": "anchor",
        "link": "https://www.openstreetmap.org/#map=13/51.51279067225417/-0.09184009399817228",
        "text": "Here is a map",
        "language": "en"
      },
      {
        "type": "map",
        "latitude": "51.51279067225417",
        "longitude": "-0.09184009399817228",
        "zoom": "13",
        "language": "en"
      }
```

Sorry for the repeated PR, missed this in the last one.

@DravitLochan @saurabhjn76 @dynamitechetan @madhavrathi @isuruAb @rishiraj824 Please review
