### PR TITLE
Changed createSkill.txt to createSkill.json

### DIFF
--- a/src/ai/susi/server/api/cms/CreateSkillService.java
+++ b/src/ai/susi/server/api/cms/CreateSkillService.java
@@ -50,7 +50,7 @@ public class CreateSkillService extends AbstractAPIHandler implements APIHandler
 
     @Override
     public String getAPIPath() {
-        return "/cms/createSkill.txt";
+        return "/cms/createSkill.json";
     }
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {


### PR DESCRIPTION

Changes: Changed createSkill.txt endpoint to createSkill.json. The output and the response type were already in JSON.


