### PR TITLE
Remove host from getAllUser, first user to signup becomes admin and fix for deletion of account

### DIFF
--- a/src/ai/susi/DAO.java
+++ b/src/ai/susi/DAO.java
@@ -358,6 +358,10 @@ public class DAO {
 		}
 		return i;
 	}
+
+	public static void deleteAuthorization(@Nonnull ClientIdentity credential) {
+	    authorization.remove(credential.toString());
+    }
     
     public static Accounting getAccounting(@Nonnull ClientIdentity identity) {
          return new Accounting(identity, accounting);

--- a/src/ai/susi/DAO.java
+++ b/src/ai/susi/DAO.java
@@ -340,7 +340,7 @@ public class DAO {
 	public static void deleteAuthentication(@Nonnull ClientCredential credential) {
 		authentication.remove(credential.toString());
 	}
-	
+
 	public static Authorization getAuthorization(@Nonnull ClientIdentity identity) {
 		 return new Authorization(identity, authorization);
 	}
@@ -352,6 +352,8 @@ public class DAO {
 	public static Collection<ClientIdentity> getAuthorizedClients() {
 		ArrayList<ClientIdentity> i = new ArrayList<>();
 		for (String id: authorization.keys()) {
+		    if(id.contains("host"))
+		        continue;
 			i.add(new ClientIdentity(id));
 		}
 		return i;

--- a/src/ai/susi/server/api/aaa/GetAllUsers.java
+++ b/src/ai/susi/server/api/aaa/GetAllUsers.java
@@ -50,7 +50,6 @@ public class GetAllUsers extends AbstractAPIHandler implements APIHandler {
         Collection<ClientIdentity> authorized = DAO.getAuthorizedClients();
         List<String> keysList = new ArrayList<String>();
         authorized.forEach(client -> keysList.add(client.toString()));
-        keysList.remove(keysList.size()-1);
         String[] keysArray = keysList.toArray(new String[keysList.size()]);
         JSONObject users = new JSONObject();
         authorized.forEach(client -> users.put(client.getClient(), client.toJSON()));

--- a/src/ai/susi/server/api/aaa/LoginService.java
+++ b/src/ai/susi/server/api/aaa/LoginService.java
@@ -106,7 +106,11 @@ public class LoginService extends AbstractAPIHandler implements APIHandler {
 			if (delete) {
 	            ClientCredential pwcredential = new ClientCredential(authorization.getIdentity());
 			    delete = DAO.hasAuthentication(pwcredential);
-			    if (delete) DAO.deleteAuthentication(pwcredential);
+			    delete = DAO.hasAuthorization(authorization.getIdentity());
+			    if (delete) {
+					DAO.deleteAuthorization(authorization.getIdentity());
+					DAO.deleteAuthentication(pwcredential);
+				}
 			}
 			
 			JSONObject result = new JSONObject(true);

--- a/src/ai/susi/server/api/aaa/SignUpService.java
+++ b/src/ai/susi/server/api/aaa/SignUpService.java
@@ -6,12 +6,12 @@
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either
  *  version 2.1 of the License, or (at your option) any later version.
- *  
+ *
  *  This library is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Lesser General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program in the file lgpl21.txt
  *  If not, see <http://www.gnu.org/licenses/>.
@@ -21,6 +21,9 @@ package ai.susi.server.api.aaa;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletResponse;
@@ -60,11 +63,11 @@ public class SignUpService extends AbstractAPIHandler implements APIHandler {
 		result.put("message", "Error: Unable to process you request");
 
 		switch(baseUserRole){
-		    case BUREAUCRAT:
-		    case ADMIN:
-		    case ACCOUNTCREATOR:
-		    case REVIEWER:
-		    case USER:
+			case BUREAUCRAT:
+			case ADMIN:
+			case ACCOUNTCREATOR:
+			case REVIEWER:
+			case USER:
 				result.put("register", true); // allow to register new users (this bypasses email verification and activation)
 				result.put("activate", true); // allow to activate new users
 				result.put("accepted", true);
@@ -110,7 +113,7 @@ public class SignUpService extends AbstractAPIHandler implements APIHandler {
 		// is this a verification?
 		if (post.get("validateEmail", null) != null) {
 			if((auth.getIdentity().getName().equals(post.get("validateEmail", null)) && auth.getIdentity().isEmail()) // the user is logged in via an access token from the email
-				|| permissions.getBoolean("activate", false)){ // the user is allowed to activate other users
+					|| permissions.getBoolean("activate", false)){ // the user is allowed to activate other users
 
 				ClientCredential credential = new ClientCredential(ClientCredential.Type.passwd_login,
 						auth.getIdentity().getName());
@@ -202,7 +205,15 @@ public class SignUpService extends AbstractAPIHandler implements APIHandler {
 
 		// set authorization details
 		Authorization authorization = DAO.getAuthorization(identity);
-		authorization.setUserRole(UserRole.USER);
+		Collection<ClientIdentity> authorized = DAO.getAuthorizedClients();
+		List<String> keysList = new ArrayList<String>();
+		authorized.forEach(client -> keysList.add(client.toString()));
+		String[] keysArray = keysList.toArray(new String[keysList.size()]);
+		if(keysArray.length == 1) {
+			authorization.setUserRole(UserRole.ADMIN);
+		} else {
+			authorization.setUserRole(UserRole.USER);
+		}
 
 		if (sendEmail) {
 			String token = createRandomString(30);
@@ -232,7 +243,7 @@ public class SignUpService extends AbstractAPIHandler implements APIHandler {
 
 	/**
 	 * Read Email template and insert variables
-	 * 
+	 *
 	 * @param token
 	 *            - login token
 	 * @return Email String
@@ -243,7 +254,7 @@ public class SignUpService extends AbstractAPIHandler implements APIHandler {
 		if(hostUrl == null) throw new APIException(500, "No host url configured");
 
 		String verificationLink = hostUrl + "/aaa/signup.json?access_token=" + token
-                + "&validateEmail=" + userId + "&request_session=true";
+				+ "&validateEmail=" + userId + "&request_session=true";
 
 		// get template file
 		String result;

--- a/src/ai/susi/server/api/aaa/SignUpService.java
+++ b/src/ai/susi/server/api/aaa/SignUpService.java
@@ -210,7 +210,7 @@ public class SignUpService extends AbstractAPIHandler implements APIHandler {
 		authorized.forEach(client -> keysList.add(client.toString()));
 		String[] keysArray = keysList.toArray(new String[keysList.size()]);
 		if(keysArray.length == 1) {
-			authorization.setUserRole(UserRole.ADMIN);
+			authorization.setUserRole(UserRole.BUREAUCRAT);
 		} else {
 			authorization.setUserRole(UserRole.USER);
 		}


### PR DESCRIPTION
Fixes issue #445 , #446 , #481 

Changes: First user to signup on the server will be made admin by default; while iterating through the list of authorized clients, if host is encountered then don't include it in the array; on deleting account, user removed from authorization file as well.
before : 
![before](https://user-images.githubusercontent.com/14837478/29201595-3beddc56-7e7d-11e7-907d-db66e9718873.png)

after : 
![after](https://user-images.githubusercontent.com/14837478/29201594-3bc5d65c-7e7d-11e7-96d9-ca1d8a353dab.png)

