### PR TITLE
refractor skill rating endpoint

### DIFF
--- a/src/ai/susi/server/api/cms/GetSkillRatingService.java
+++ b/src/ai/susi/server/api/cms/GetSkillRatingService.java
@@ -17,7 +17,7 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package ai.susi.server.api.aaa;
+package ai.susi.server.api.cms;
 
 import ai.susi.DAO;
 import ai.susi.json.JsonObjectWithDefault;


### PR DESCRIPTION
Fixes issue #479 
Changes: moved GetSkillRatingService to CMS

Screenshots for the change: N\A
