### PR TITLE
Add susi skill repo to Dockerfile

### DIFF
--- a/kubernetes/images/Dockerfile
+++ b/kubernetes/images/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get upgrade -y
 # add packages
 RUN apt-get install -y git openjdk-8-jdk
 
+RUN cd / && git clone https://github.com/fossasia/susi_skill_data.git
+
 # clone the github repo
 RUN git clone https://github.com/fossasia/susi_server.git /susi_server
 WORKDIR /susi_server


### PR DESCRIPTION
progress on #240 

Changes: added susi_skill_repo to docker-file.

deployment link for testing:  http://35.202.253.176/
http://35.202.253.176/cms/getSkillMetadata.json?model=general&group=Knowledge&language=en&skill=president.

Next, we need to update the skill_data_repository, using java client.(issue #499)
