### PR TITLE
Modify Skill Service can now rename, update content, update image etc

### DIFF
--- a/src/ai/susi/server/api/cms/ModifySkillService.java
+++ b/src/ai/susi/server/api/cms/ModifySkillService.java
@@ -62,7 +62,7 @@ public class ModifySkillService extends AbstractAPIHandler implements APIHandler
     private static final long serialVersionUID = -1834363513093189312L;
 
     @Override
-    public UserRole getMinimalUserRole() { return UserRole.ANONYMOUS; }
+    public UserRole getMinimalUserRole() { return UserRole.USER; }
 
     @Override
     public JSONObject getDefaultPermissions(UserRole baseUserRole) {
@@ -81,6 +81,8 @@ public class ModifySkillService extends AbstractAPIHandler implements APIHandler
 
     @Override
     protected void doPost(HttpServletRequest call, HttpServletResponse resp) throws ServletException, IOException {
+        // CORS Header 
+        resp.setHeader("Access-Control-Allow-Origin", "*");
         // GET OLD VALUES HERE
         String model_name = call.getParameter("OldModel");
         if(model_name==null){


### PR DESCRIPTION
This endpoint can now rename skills, update the content of skills, update image, rename images, change categories and languages of skills and images.
Fixes issue #502 
Commits made in testing are at my local branch https://github.com/dynamitechetan/susi_skill_data/commits/aaCMS
127.0.0.1:4000/cms/modifySkill.json This endpoint will accept post data as
```
OldModel:general
OldGroup:Knowledge
OlaLanguage:en
OldSkill:github
NewModel:general
NewGroup:Knowledge
NewLanguage:en
NewSkill:github
changelog:change image name
content:asdasdasdadsadsaasd
imageChanged:false
old_image_name:github.png
new_image_name:githuba.png
image_name_changed:true
image: <image oject>
```