### PR TITLE
return accounting attributes in response of getUser

### DIFF
--- a/src/ai/susi/server/api/aaa/GetAllUsers.java
+++ b/src/ai/susi/server/api/aaa/GetAllUsers.java
@@ -3,15 +3,7 @@ package ai.susi.server.api.aaa;
 import ai.susi.DAO;
 import ai.susi.json.JsonObjectWithDefault;
 
-import ai.susi.server.APIException;
-import ai.susi.server.APIHandler;
-import ai.susi.server.AbstractAPIHandler;
-import ai.susi.server.Authorization;
-import ai.susi.server.UserRole;
-import ai.susi.server.ClientIdentity;
-import ai.susi.server.Query;
-import ai.susi.server.ServiceResponse;
-import ai.susi.server.Client;
+import ai.susi.server.*;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -22,16 +14,16 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- Created by chetankaushik on 31/05/17.
- This Servlet gives a API Endpoint to list all the users and their roles.
- It requires user role to be ADMIN or above ADMIN
- example:
- http://localhost:4000/aaa/getUsers.json?access_token=go2ijgk5ijkmViAac2bifng3uthdZ
- Necessary parameters : access_token
- Other parameters (one out of two is necessary):
- getPageCount -> boolean http://localhost:4000/aaa/getUsers.json?access_token=go2ijgk5ijkmViAac2bifng3uthdZ&getPageCount=true
- getUserCount -> boolean http://localhost:4000/aaa/getUsers.json?access_token=go2ijgk5ijkmViAac2bifng3uthdZ&getUserCount=true
- page         -> integer http://localhost:4000/aaa/getUsers.json?access_token=go2ijgk5ijkmViAac2bifng3uthdZ&page=2
+ * Created by chetankaushik on 31/05/17.
+ * This Servlet gives a API Endpoint to list all the users and their roles.
+ * It requires user role to be ADMIN or above ADMIN
+ * example:
+ * http://localhost:4000/aaa/getUsers.json?access_token=go2ijgk5ijkmViAac2bifng3uthdZ
+ * Necessary parameters : access_token
+ * Other parameters (one out of two is necessary):
+ * getPageCount -> boolean http://localhost:4000/aaa/getUsers.json?access_token=go2ijgk5ijkmViAac2bifng3uthdZ&getPageCount=true
+ * getUserCount -> boolean http://localhost:4000/aaa/getUsers.json?access_token=go2ijgk5ijkmViAac2bifng3uthdZ&getUserCount=true
+ * page         -> integer http://localhost:4000/aaa/getUsers.json?access_token=go2ijgk5ijkmViAac2bifng3uthdZ&page=2
  */
 public class GetAllUsers extends AbstractAPIHandler implements APIHandler {
 
@@ -83,10 +75,48 @@ public class GetAllUsers extends AbstractAPIHandler implements APIHandler {
             //authorized.forEach(client -> userList.add(client.toJSON()));
             for (Client client : authorized) {
                 JSONObject json = client.toJSON();
+
+                // generate client identity to get user role
                 ClientIdentity identity = new ClientIdentity(ClientIdentity.Type.email, client.getName());
                 Authorization authorization = DAO.getAuthorization(identity);
                 UserRole userRole = authorization.getUserRole();
+
+                // put user role in response
                 json.put("userRole", userRole.toString().toLowerCase());
+
+                //generate client credentials to get status whether verified or not
+                ClientCredential clientCredential = new ClientCredential(ClientCredential.Type.passwd_login, identity.getName());
+                Authentication authentication = DAO.getAuthentication(clientCredential);
+
+                //put verified status in response
+                json.put("confirmed", authentication.getBoolean("accepted", false));
+
+                /* Generate accounting object to get details like last login IP,
+                 * signup time and last login time and put it in the response
+                 * */
+                Accounting accounting = DAO.getAccounting(authorization.getIdentity());
+                if (accounting.getJSON().has("lastLoginIP")) {
+                    json.put("lastLoginIP", accounting.getJSON().getString("lastLoginIP"));
+                }
+                else {
+                    json.put("lastLoginIP", "");
+                }
+
+                if(accounting.getJSON().has("signupTime")) {
+                    json.put("signupTime", accounting.getJSON().getString("signupTime"));
+                }
+                else {
+                    json.put("signupTime", "");
+                }
+
+                if(accounting.getJSON().has("lastLoginTime")) {
+                    json.put("lastLoginTime", accounting.getJSON().getString("lastLoginTime"));
+                }
+                else {
+                    json.put("lastLoginTime", "");
+                }
+
+                //add the user details in the list
                 userList.add(json);
             }
             List<JSONObject> currentPageUsers = new ArrayList<JSONObject>();

--- a/src/ai/susi/server/api/aaa/GetAllUsers.java
+++ b/src/ai/susi/server/api/aaa/GetAllUsers.java
@@ -3,7 +3,19 @@ package ai.susi.server.api.aaa;
 import ai.susi.DAO;
 import ai.susi.json.JsonObjectWithDefault;
 
-import ai.susi.server.*;
+
+import ai.susi.server.APIException;
+import ai.susi.server.APIHandler;
+import ai.susi.server.AbstractAPIHandler;
+import ai.susi.server.Accounting;
+import ai.susi.server.Authentication;
+import ai.susi.server.ClientCredential;
+import ai.susi.server.Authorization;
+import ai.susi.server.UserRole;
+import ai.susi.server.ClientIdentity;
+import ai.susi.server.Query;
+import ai.susi.server.ServiceResponse;
+import ai.susi.server.Client;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -89,7 +101,7 @@ public class GetAllUsers extends AbstractAPIHandler implements APIHandler {
                 Authentication authentication = DAO.getAuthentication(clientCredential);
 
                 //put verified status in response
-                json.put("confirmed", authentication.getBoolean("accepted", false));
+                json.put("confirmed", authentication.getBoolean("activated", false));
 
                 /* Generate accounting object to get details like last login IP,
                  * signup time and last login time and put it in the response

--- a/src/ai/susi/server/api/aaa/LoginService.java
+++ b/src/ai/susi/server/api/aaa/LoginService.java
@@ -220,6 +220,11 @@ public class LoginService extends AbstractAPIHandler implements APIHandler {
 
 			result.put("message", "You are logged in as " + identity.getName());
 			result.put("accepted", true);
+
+			// store the IP of last login in accounting object
+			Accounting accouting = DAO.getAccounting(identity);
+			accouting.getJSON().put("lastLoginIP", post.getClientHost());
+
 			return new ServiceResponse(result);
 		}
 		else if(pubkeyHello){ // first part of pubkey login: if the key hash is known, create a challenge


### PR DESCRIPTION
Fixes issue #487 
Changes: after this pr, server will store last login IP of the user and will return last login IP, last login time and signup time. If any of the details is missing, it will return an empty string.
Server will also tell if user is verified or not.

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/14837478/29284011-b1f19570-8146-11e7-98ae-d20bfc15e1c9.png)

