### PR TITLE
Feat: Delete Skill Stores a deleted skill for 30 days

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ def versionJersey = '2.22.2'
 buildscript {
   repositories {
     jcenter()
+    mavenCentral()
   }
 
   dependencies {
@@ -89,7 +90,7 @@ dependencies {
   compile group: 'org.glassfish.jersey.core', name: 'jersey-server', version: versionJersey
   compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet-core', version: versionJersey
   compile group: 'org.webjars', name: 'swagger-ui', version: '2.1.4'
-
+  compile group: 'commons-io', name: 'commons-io', version: '2.4'
   // the following is required for public-transport-enabler
   compile 'com.squareup.okhttp3:okhttp:3.8.0'
   compile 'com.squareup.okhttp3:logging-interceptor:3.8.0'

--- a/src/ai/susi/Caretaker.java
+++ b/src/ai/susi/Caretaker.java
@@ -19,9 +19,16 @@
 
 package ai.susi;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.AgeFileFilter;
+import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.eclipse.jetty.util.log.Log;
 
 import ai.susi.tools.TimeoutMatcher;
+import org.joda.time.DateTime;
+
+import java.io.File;
+import java.util.Collection;
 
 
 /**
@@ -42,15 +49,25 @@ public class Caretaker extends Thread {
         this.interrupt();
         Log.getLog().info("catched caretaker termination signal");
     }
-    
+
+    public void deleteOldFiles() {
+        Collection<File> filesToDelete = FileUtils.listFiles(new File(DAO.deleted_skill_dir.getPath()),
+                new AgeFileFilter(DateTime.now().withTimeAtStartOfDay().minusDays(30).toDate()),
+                TrueFileFilter.TRUE);    // include sub dirs
+        for (File file : filesToDelete) {
+            boolean success = FileUtils.deleteQuietly(file);
+            if (!success) {
+                System.out.print("Deleted skill older than 30 days.");
+            }
+        }
+    }
     @Override
     public void run() {
         
         boolean busy = false;
         // work loop
         beat: while (this.shallRun) try {
-            
-            
+            deleteOldFiles();
             // sleep a bit to prevent that the DoS limit fires at backend server
             try {Thread.sleep(busy ? 1000 : 5000);} catch (InterruptedException e) {}
             TimeoutMatcher.terminateAll();

--- a/src/ai/susi/DAO.java
+++ b/src/ai/susi/DAO.java
@@ -88,7 +88,7 @@ import org.json.JSONObject;
 public class DAO {
 
     private final static String ACCESS_DUMP_FILE_PREFIX = "access_";
-    public  static File conf_dir, bin_dir, html_dir, data_dir, susi_memory_dir, model_watch_dir, susi_skill_repo;
+    public  static File conf_dir, bin_dir, html_dir, data_dir, susi_memory_dir, model_watch_dir, susi_skill_repo, deleted_skill_dir;
     private static File external_data, assets, dictionaries;
     private static Settings public_settings, private_settings;
     public  static AccessTracker access;
@@ -122,6 +122,9 @@ public class DAO {
         html_dir = new File("html");
         data_dir = dataPath.toFile().getAbsoluteFile();
         susi_memory_dir = new File(data_dir, "susi");
+        // TODO:
+        deleted_skill_dir = new File(new File(DAO.data_dir, "deleted_skill_dir"), "models");
+
         model_watch_dir = new File(new File(data_dir.getParentFile().getParentFile(), "susi_skill_data"), "models");
         susi_skill_repo = new File(data_dir.getParentFile().getParentFile(), "susi_skill_data/.git");
 

--- a/src/ai/susi/server/api/cms/DeleteSkillService.java
+++ b/src/ai/susi/server/api/cms/DeleteSkillService.java
@@ -3,6 +3,7 @@ package ai.susi.server.api.cms;
 import ai.susi.DAO;
 import ai.susi.json.JsonObjectWithDefault;
 import ai.susi.server.*;
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.joda.time.DateTime;
@@ -11,6 +12,7 @@ import org.json.JSONObject;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
+import java.util.Date;
 
 
 /**
@@ -34,7 +36,7 @@ public class DeleteSkillService extends AbstractAPIHandler implements APIHandler
 
     @Override
     public String getAPIPath() {
-        return "/cms/deleteSkill.txt";
+        return "/cms/deleteSkill.json";
     }
 
     @Override
@@ -62,6 +64,8 @@ public class DeleteSkillService extends AbstractAPIHandler implements APIHandler
             File file = new File(DAO.deleted_skill_dir.getPath()+path);
             file.getParentFile().mkdirs();
             if(skill.renameTo(file)){
+                Boolean changed =  new File(DAO.deleted_skill_dir.getPath()+path).setLastModified(System.currentTimeMillis());
+                System.out.print(changed);
                 System.out.println("Skill moved successfully!");
             }else{
                 System.out.println("Skill failed to move!");


### PR DESCRIPTION
Fixes #486  
Delete Skill Endpoint is now able to delete a skill. 
The skill should be moved to an area "deleted skills" and be deleted automatically after 30 days.
http://127.0.0.1:4000/cms/deleteSkill.txt?skill=gender
