### PR TITLE
remove redundant mavenCentral repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ def versionJersey = '2.22.2'
 buildscript {
   repositories {
     jcenter()
-    mavenCentral()
   }
 
   dependencies {


### PR DESCRIPTION
jcenter() is superset of mavenCentral() so it is redundant to use mavenCentral after jcenter.
