### PR TITLE
Update readme for broken skill tutorial link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,8 @@ How do I develop Skills (AI Conversation Rules) for Susi AI?
 ---------------------------------------------------------
 
 The Susi AI skill language is described in the `Skill Development
-Tutorial </docs/skills/susi_skill_development_tutorial.md>`__.
+Tutorial <https://github.com/fossasia/susi_skill_data/blob/master/README_susi_skill_language_tutorial.md>`__.
+
 
 Why should I use Susi AI?
 ----------------------


### PR DESCRIPTION
Fixes #608 

Changes: Earlier Link location was deleted https://github.com/fossasia/susi_server/commit/007b04a7d960115ee9c8fbcff47d3cfaa9ef3cc7#diff-0ddc48b8dccdbe0130da5315f5d362db .
So provided the link to ['submitting_skills_to_git'](https://github.com/fossasia/susi_server/blob/development/docs/skills/submitting_skills_to_git.md).
