### PR TITLE
.travis.yml: Parallelize Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,40 @@
-language: java
 dist: trusty
 sudo: required
-jdk:
-- oraclejdk8
+
 env:
   global:
   - secure: DbveaxDMtEP+/Er6ktKCP+P42uDU8xXWRBlVGaqVNU3muaRmmZtj8ngAARxfzY0f9amlJlCavqkEIAumQl9BYKPWIra28ylsLNbzAoCIi8alf9WLgddKwVWsTcZo9+UYocuY6UivJVkofycfFJ1blw/83dWMG0/TiW6s/SrwoDw=
   - >-
   - PATH=$PATH:${HOME}/google-cloud-sdk/bin 
     CLOUDSDK_CORE_DISABLE_PROMPTS=1
-script:
-- gradle assemble
-- gradle clean
-before_script:
-- pip install --user codecov
-install: true
-after_success:
-- if [ -e ./gradlew ]; then ./gradlew test jacocoTestReport;else gradle test jacocoTestReport;fi
-- bash <(curl -s https://codecov.io/bash)
-- bash kubernetes/travis/deploy.sh
-- bash kubernetes/travis/deploy-master.sh
-- codecov
-deploy:
-- provider: heroku
-  buildpack: https://github.com/yukiisbored/heroku_buildpack_gradle_loklak
-  api_key:
-    secure: CqW0sgNQiVHA2bUaTpWBd5xslu1LQaBRuT9t/XIhes1WQbJ7+rfsqPb1FFPS6cD8o+7Pgx7hCmIyKxcchrmk8Oat2jrO59fe8i3xuOh/Tl9os8PWy0Y2Kbsd4zjWODMC++ioY9sJKB71fhkA1sZjemo10cDLB0jp5P9vmGwj+34H8h2Mw/kA/CggD+lu52ZR/LqLT+QYTF+l5Q9wF1PdCMYNMi2zis3bKjvt6psCMjfQ9PA+C8GjhrA3d5hd6ToIekPaFXk179ev+FbAzJrVo9Ltste7JHRhtm2e+5juSjkpt1jh/l97DHoVLkIyWUNBuR+owfTEPFotFFhLfFJ048NBM9fCoGdJ8kRWpuaFCzu3UeQQODVVlqJHyShBFiaGrOiJPK8V9mSCXVVoU4D6NM/W8CXAhgdAY1jpzjAvwShCnnpOU9aBTzPGNhFJvl01QiM+mIgaIyyW3/Zb5lorzUA89+DgTMZucQKn8oFagsC+nxl7T0dgNML4JnWnKGh7cqnUSS8lTdHBIgEdq8kxFxpM5BEzQ85B1/pmlPeiop/hilq3onXgv3+qMLajRV0KE/GQg11XV8z/9qFBm8LppfUYJeKkjCg/vKsJfnOmj8Z6GDOZyVx5JAQ0Kd9e5Ds/yObmqaih6gKdoJlypkN94WMvEQsochS+/Ld3jxvLQaU=
-  app: susi-server
-  on:
-    branch: development
+
+matrix:
+  include:
+    # Build, test and deploy to Google Cloud and Heroku
+    - language: java
+      jdk: oraclejdk8
+      script:
+        - gradle assemble
+        - gradle clean
+      install: true
+      after_success:
+        - if [ -e ./gradlew ]; then ./gradlew test jacocoTestReport;else gradle test jacocoTestReport;fi
+        - bash kubernetes/travis/deploy.sh
+        - bash kubernetes/travis/deploy-master.sh
+      deploy:
+        - provider: heroku
+          buildpack: https://github.com/yukiisbored/heroku_buildpack_gradle_loklak
+          api_key:
+            secure: CqW0sgNQiVHA2bUaTpWBd5xslu1LQaBRuT9t/XIhes1WQbJ7+rfsqPb1FFPS6cD8o+7Pgx7hCmIyKxcchrmk8Oat2jrO59fe8i3xuOh/Tl9os8PWy0Y2Kbsd4zjWODMC++ioY9sJKB71fhkA1sZjemo10cDLB0jp5P9vmGwj+34H8h2Mw/kA/CggD+lu52ZR/LqLT+QYTF+l5Q9wF1PdCMYNMi2zis3bKjvt6psCMjfQ9PA+C8GjhrA3d5hd6ToIekPaFXk179ev+FbAzJrVo9Ltste7JHRhtm2e+5juSjkpt1jh/l97DHoVLkIyWUNBuR+owfTEPFotFFhLfFJ048NBM9fCoGdJ8kRWpuaFCzu3UeQQODVVlqJHyShBFiaGrOiJPK8V9mSCXVVoU4D6NM/W8CXAhgdAY1jpzjAvwShCnnpOU9aBTzPGNhFJvl01QiM+mIgaIyyW3/Zb5lorzUA89+DgTMZucQKn8oFagsC+nxl7T0dgNML4JnWnKGh7cqnUSS8lTdHBIgEdq8kxFxpM5BEzQ85B1/pmlPeiop/hilq3onXgv3+qMLajRV0KE/GQg11XV8z/9qFBm8LppfUYJeKkjCg/vKsJfnOmj8Z6GDOZyVx5JAQ0Kd9e5Ds/yObmqaih6gKdoJlypkN94WMvEQsochS+/Ld3jxvLQaU=
+          app: susi-server
+          on:
+            branch: development
+
+    # Codecov
+    - language: generic
+      before_script: pip install --user codecov
+      install: true
+      script:
+        - bash <(curl -s https://codecov.io/bash)
+        - codecov
 


### PR DESCRIPTION
Parallelizes build acress multiple virtual instances in Travis so that
tests could run smoother and in a clear fashon. Seperates codecov to
another virtual instance to improve speed, readability and accessibility
of the Travis CI logs.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>

Fixes #632 

Link to view the change: https://travis-ci.org/abishekvashok/susi_server

**Note:** the build is failing as the app will only be deployed via a direct commit in the `susi_server` repository. As my fork's name is not `fossasia/susi_server`, the secure token would not be decrypted. Hence, I again assert that this PR is absolutely fine :)

@fossasia/susi-ai-devops please review.