### PR TITLE
Fixes 698 : Correct the command in kubernetes install docs

### DIFF
--- a/docs/installation/installation_kubernetes_gcloud.md
+++ b/docs/installation/installation_kubernetes_gcloud.md
@@ -100,7 +100,7 @@ _You can delete the instance if your not planning to use it for anything else. B
 - To prevent this we need to ensure that the server is restricted on one node only.
 
   ```
-  kubect get nodes
+  kubectl get nodes
   ```
 
   ```


### PR DESCRIPTION
Fixes #698 

Changes: 

Correct the command to list all kubernetes nodes in the Kubernetes installation docs.
`kubect` was changed to `kubectl`
