### PR TITLE
Correct typo in get nodes command (Fixed #703)

### DIFF
--- a/docs/installation/installation_kubernetes_gcloud.md
+++ b/docs/installation/installation_kubernetes_gcloud.md
@@ -100,7 +100,7 @@ _You can delete the instance if your not planning to use it for anything else. B
 - To prevent this we need to ensure that the server is restricted on one node only.
 
   ```
-  kubect get nodes
+  kubectl get nodes
   ```
 
   ```


### PR DESCRIPTION
Fixes #703
Changes : There is a minor typo in the word kubectl. Corrected 'kubect' to 'kubectl'.

