### PR TITLE
Removes unwanted file and updates gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.iml
 /hs_err_*.log
 /data.bkp/
+/out/*
 
 *.xml~
 


### PR DESCRIPTION
- Removes `java` an empty text file with that name introduced in 5425ce7cdb757c50da9627aa3a023d36e1ad23e2
- Updates gitignore to include `out/` generated by IntelliJ