### PR TITLE
Added an API to store device information in the accounting model of the User

### DIFF
--- a/src/ai/susi/SusiServer.java
+++ b/src/ai/susi/SusiServer.java
@@ -486,6 +486,7 @@ public class SusiServer {
                 LanguageListService.class,
                 ListUserSettings.class,
                 ListSkillService.class,
+                AddNewDevice.class,
                 DisableSkillService.class,
                 GetAllLanguages.class,
                 DeleteGroupService.class,

--- a/src/ai/susi/server/api/aaa/AddNewDevice.java
+++ b/src/ai/susi/server/api/aaa/AddNewDevice.java
@@ -1,0 +1,92 @@
+/**
+ *  AddNewDevice
+ *  Copyright by @Akshat-Jain on 24/5/18.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *  
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program in the file lgpl21.txt
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+package ai.susi.server.api.aaa;
+
+import ai.susi.DAO;
+import ai.susi.json.JsonObjectWithDefault;
+import ai.susi.server.*;
+import org.json.JSONObject;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by @Akshat-Jain on 24/5/18.
+ * Servlet to add device information
+ * This service accepts two parameter - Mac address of device and device name - and stores them in User data
+ * test locally at http://127.0.0.1:4000/aaa/addNewDevice.json?macid=macAddressOfDevice&device=deviceName&access_token=6O7cqoMbzlClxPwg1is31Tz5pjVwo3
+ */
+public class AddNewDevice extends AbstractAPIHandler implements APIHandler {
+
+    @Override
+    public String getAPIPath() {
+        return "/aaa/addNewDevice.json";
+    }
+
+    @Override
+    public UserRole getMinimalUserRole() {
+        return UserRole.USER;
+    }
+
+    @Override
+    public JSONObject getDefaultPermissions(UserRole baseUserRole) {
+        return null;
+    }
+
+    @Override
+    public ServiceResponse serviceImpl(Query query, HttpServletResponse response, Authorization authorization, JsonObjectWithDefault permissions) throws APIException {
+
+               JSONObject value = new JSONObject();
+           
+               String key = query.get("macid", null);
+               String name = query.get("name", null);
+               String device = query.get("device", null);
+               
+               if (key == null || name == null || device == null) {
+                   throw new APIException(400, "Bad service call, missing arguments");
+               } else {
+                   value.put(name, device);
+               }
+           
+           if (authorization.getIdentity() == null) {
+               throw new APIException(400, "Specified user data not found, ensure you are logged in");
+           } 
+           else {
+                Accounting accounting = DAO.getAccounting(authorization.getIdentity());
+                if (accounting.getJSON().has("devices")) {
+                       accounting.getJSON().getJSONObject("devices").put(key, value);
+                   } 
+                else {
+                       JSONObject jsonObject = new JSONObject();
+                       jsonObject.put(key, value);
+                       accounting.getJSON().put("devices", jsonObject);
+                   }
+               
+               JSONObject result = new JSONObject(true);
+               result.put("accepted", true);
+               result.put("message", "You have successfully added the device!");
+               return new ServiceResponse(result);
+           }
+       
+
+    }
+}

--- a/src/ai/susi/server/api/aaa/ListUserSettings.java
+++ b/src/ai/susi/server/api/aaa/ListUserSettings.java
@@ -9,7 +9,7 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Created by saurabh on 20/6/17.
- * Servlet to read user setting
+ * Servlet to read user setting and connected devices
  * example:
  * http://localhost:4000/aaa/listUserSettings.json?access_token=6O7cqoMbzlClxPwg1is31Tz5pjVwo3
  */
@@ -37,10 +37,10 @@ public class ListUserSettings extends AbstractAPIHandler implements APIHandler {
             Accounting accouting = DAO.getAccounting(authorization.getIdentity());
             JSONObject result = accouting.getJSON();
             result.put("accepted", true);
-            result.put("message", "Success: Showing User settings");
+            result.put("message", "Success: Showing user data");
             return new ServiceResponse(result);
         } else {
-            throw new APIException(400, "Specified User Setting not found, ensure you are logged in");
+            throw new APIException(400, "Specified user data not found, ensure you are logged in");
         }
 
     }


### PR DESCRIPTION
Fixes #727 

Changes: Added an API to store the device information in the accounting model of the User.

Screenshots for the change: 
The endpoint `/aaa/addNewDevice.json` accepts two parameter - Mac address of device (_macid_) and device name (_device_) - and stores them in User data.
The below is the JSON response for the endpoint `/aaa/addNewDevice.json` -

```
{
  "accepted": true,
  "message": "You have successfully added the device!",
  "session": {"identity": {
    "type": "email",
    "name": "akjn11@gmail.com",
    "anonymous": false
  }}
}
```

The below is the JSON response when the devices' information is fetched -
```
{
  "lastLoginIP": "127.0.0.1",
  "accepted": true,
  "message": "Success: Showing user data",
  "session": {"identity": {
    "type": "email",
    "name": "akjn11@gmail.com",
    "anonymous": false
  }},
  "devices": {
    "MacAddress1": {"MyDevice": "SmartSpeaker"},
    "MacAddress2": {"DeviceName": "SmartSpeaker"}
  }
}
```

