### PR TITLE
/cms/getSkillList.json endpoint returns list of all Skills if no query parameter is given

### DIFF
--- a/src/ai/susi/server/api/cms/ListSkillService.java
+++ b/src/ai/susi/server/api/cms/ListSkillService.java
@@ -43,7 +43,7 @@ public class ListSkillService extends AbstractAPIHandler implements APIHandler {
 
         String model_name = call.get("model", "general");
         File model = new File(DAO.model_watch_dir, model_name);
-        String group_name = call.get("group", "Knowledge");
+        String group_name = call.get("group", "All");
         String language_name = call.get("language", "en");
         JSONArray jsonArray = new JSONArray();
         JSONObject json = new JSONObject(true);


### PR DESCRIPTION
Fixes #705 

Changes: Changes /cms/getSkillList.json endpoint to return list of all skills when no query parameter is given.
