### PR TITLE
Added API to get country wise skill usage data

### DIFF
--- a/src/ai/susi/DAO.java
+++ b/src/ai/susi/DAO.java
@@ -110,6 +110,7 @@ public class DAO {
     public static JsonTray group;
     public static JsonTray skillRating;
     public static JsonTray fiveStarSkillRating;
+    public static JsonTray countryWiseSkillUsage;
 
     static {
         PatternLayout layout = new PatternLayout("%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c %x - %m%n");
@@ -258,6 +259,16 @@ public class DAO {
         fiveStarSkillRating = new JsonTray(fiveStarSkillRating_per.toFile(), fiveStarSkillRating_vol.toFile(), 1000000);
         OS.protectPath(fiveStarSkillRating_per);
         OS.protectPath(fiveStarSkillRating_vol);
+
+
+        // Country wise skill usage
+        Path country_wise_skill_usage_dir = dataPath.resolve("skill_usage");
+        country_wise_skill_usage_dir.toFile().mkdirs();
+        Path countryWiseSkillUsage_per = country_wise_skill_usage_dir.resolve("countryWiseSkillUsage.json");
+        Path countryWiseSkillUsage_vol = country_wise_skill_usage_dir.resolve("countryWiseSkillUsage_session.json");
+        countryWiseSkillUsage = new JsonTray(countryWiseSkillUsage_per.toFile(), countryWiseSkillUsage_vol.toFile(), 1000000);
+        OS.protectPath(countryWiseSkillUsage_per);
+        OS.protectPath(countryWiseSkillUsage_vol);
 
         // open index
         Path index_dir = dataPath.resolve("index");

--- a/src/ai/susi/SusiServer.java
+++ b/src/ai/susi/SusiServer.java
@@ -551,7 +551,12 @@ public class SusiServer {
                 FiveStarRateSkillService.class,
 
                 //Get rating on a particular skill by a user
-                GetRatingByUser.class
+                GetRatingByUser.class,
+
+                //Get country wise skill usage data
+                GetCountryWiseSkillUsageService.class,
+
+
 
         };
         for (Class<? extends Servlet> service: services)

--- a/src/ai/susi/mind/SusiCognition.java
+++ b/src/ai/susi/mind/SusiCognition.java
@@ -24,11 +24,13 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 
+import ai.susi.json.JsonTray;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -36,6 +38,7 @@ import org.json.JSONObject;
 import ai.susi.DAO;
 import ai.susi.server.ClientIdentity;
 import ai.susi.tools.DateParser;
+import scala.util.parsing.combinator.testing.Str;
 
 /**
  * An cognition is the combination of a query of a user with the response of susi.
@@ -48,6 +51,7 @@ public class SusiCognition {
             final String query,
             int timezoneOffset,
             double latitude, double longitude,
+            String countryCode, String countryName,
             String languageName,
             int maxcount, ClientIdentity identity,
             final SusiMind... minds) {
@@ -64,6 +68,7 @@ public class SusiCognition {
             observation.addObservation("latitude", Double.toString(latitude));
             observation.addObservation("longitude", Double.toString(longitude));
         }
+
         
         SusiLanguage language = SusiLanguage.parse(languageName);
         if (language != SusiLanguage.unknown) observation.addObservation("language", language.name());
@@ -75,6 +80,19 @@ public class SusiCognition {
         // compute the mind's reaction: here we compute with a hierarchy of minds. The dispute is taken from the relevant mind level that was able to compute the dispute
         List<SusiThought> dispute = SusiMind.reactMinds(query, language, maxcount, client, observation, minds);
         long answer_date = System.currentTimeMillis();
+
+        if (!countryCode.equals("") && !countryName.equals("")) {
+            List<String> skills = dispute.get(0).getSkills();
+            for (String skill : skills) {
+                try {
+                    updateCountryWiseUsageData(skill, countryCode, countryName);
+                }
+                catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
         
         // store answer and actions into json
         this.json.put("answers", new JSONArray(dispute));
@@ -82,7 +100,69 @@ public class SusiCognition {
         this.json.put("answer_time", answer_date - query_date);
         this.json.put("language", language.name());
     }
-    
+
+    private void updateCountryWiseUsageData(String skillPath, String countryCode, String countryName) {
+        String skillInfo[] = skillPath.split("/");
+        String model_name = skillInfo[3];
+        String group_name = skillInfo[4];
+        String language_name = skillInfo[5];
+        String skill_name = skillInfo[6].split("\\.")[0];
+        JsonTray skillUsage = DAO.countryWiseSkillUsage;
+        JSONObject modelName = new JSONObject();
+        JSONObject groupName = new JSONObject();
+        JSONObject languageName = new JSONObject();
+        if (skillUsage.has(model_name)) {
+            modelName = skillUsage.getJSONObject(model_name);
+            if (modelName.has(group_name)) {
+                groupName = modelName.getJSONObject(group_name);
+                if (groupName.has(language_name)) {
+                    languageName = groupName.getJSONObject(language_name);
+                    if (languageName.has(skill_name)) {
+                        JSONArray countryWiseUsageData = languageName.getJSONArray(skill_name);
+                        Boolean countryExists = false;
+                        for (int i = 0; i<countryWiseUsageData.length(); i++) {
+                            JSONObject countryUsage = countryWiseUsageData.getJSONObject(i);
+                            if (countryUsage.get("country_code").equals(countryCode)){
+                                countryUsage.put("count", countryUsage.getInt("count")+1);
+                                countryWiseUsageData.put(i,countryUsage);
+                                countryExists = true;
+                                break;
+                            }
+                        }
+
+                        if (!countryExists) {
+                            JSONObject countryUsage = new JSONObject();
+                            countryUsage.put("country_code", countryCode);
+                            countryUsage.put("country_name", countryName);
+                            countryUsage.put("count", "1");
+                            countryWiseUsageData.put(countryUsage);
+                        }
+
+
+
+                        languageName.put(skill_name, countryWiseUsageData);
+                        groupName.put(language_name, languageName);
+                        modelName.put(group_name, groupName);
+                        skillUsage.put(model_name, modelName, true);
+                        return;
+
+                    }
+                }
+            }
+        }
+        JSONArray countryWiseUsageData = new JSONArray();
+        JSONObject countryUsage = new JSONObject();
+        countryUsage.put("country_code", countryCode);
+        countryUsage.put("country_name", countryName);
+        countryUsage.put("count", "1");
+        countryWiseUsageData.put(countryUsage);
+        languageName.put(skill_name, countryWiseUsageData);
+        groupName.put(language_name, languageName);
+        modelName.put(group_name, groupName);
+        skillUsage.put(model_name, modelName, true);
+        return;
+    }
+
     public SusiCognition(JSONObject json) {
         this.json = json;
     }

--- a/src/ai/susi/mind/SusiMind.java
+++ b/src/ai/susi/mind/SusiMind.java
@@ -349,7 +349,7 @@ public class SusiMind {
     
     /**
      * react on a user input: this causes the selection of deduction intents and the evaluation of the process steps
-     * in every intent up to the moment where enough intents have been applied as consideration. The reaction may also
+     * in every intent up to the moment where enough intents have been applied as consideration. The reaobservationction may also
      * cause the evaluation of operational steps which may cause learning effects within the SusiMind.
      * @param query the user input
      * @param maxcount the maximum number of answers (typical is only one)

--- a/src/ai/susi/server/api/cms/GetCountryWiseSkillUsageService.java
+++ b/src/ai/susi/server/api/cms/GetCountryWiseSkillUsageService.java
@@ -1,0 +1,103 @@
+/**
+ *  GetCountryWiseSkillUsageService
+ *  Copyright by Anup Kumar Panwar, @anupkumarpanwar
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program in the file lgpl21.txt
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ai.susi.server.api.cms;
+
+import ai.susi.DAO;
+import ai.susi.json.JsonObjectWithDefault;
+import ai.susi.json.JsonTray;
+import ai.susi.mind.SusiSkill;
+import ai.susi.server.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+
+
+/**
+ * This Endpoint accepts 4 parameters. model,group,language,skill
+ * before getting a rating of a skill, the skill must exist in the directory.
+ * http://localhost:4000/cms/getCountryWiseSkillUsage.json?model=general&group=Knowledge&skill=aboutsusi&language=en
+ */
+public class GetCountryWiseSkillUsageService extends AbstractAPIHandler implements APIHandler {
+
+
+    private static final long serialVersionUID = 1420414106164188352L;
+
+    @Override
+    public UserRole getMinimalUserRole() {
+        return UserRole.ANONYMOUS;
+    }
+
+    @Override
+    public JSONObject getDefaultPermissions(UserRole baseUserRole) {
+        return null;
+    }
+
+    @Override
+    public String getAPIPath() {
+        return "/cms/getCountryWiseSkillUsage.json";
+    }
+
+    @Override
+    public ServiceResponse serviceImpl(Query call, HttpServletResponse response, Authorization rights, final JsonObjectWithDefault permissions) {
+
+        String model_name = call.get("model", "general");
+        File model = new File(DAO.model_watch_dir, model_name);
+        String group_name = call.get("group", "Knowledge");
+        File group = new File(model, group_name);
+        String language_name = call.get("language", "en");
+        File language = new File(group, language_name);
+        String skill_name = call.get("skill", null);
+        File skill = SusiSkill.getSkillFileInLanguage(language, skill_name, false);
+
+        JSONObject result = new JSONObject();
+        result.put("accepted", false);
+        if (!skill.exists()) {
+            result.put("message", "Skill does not exist");
+            return new ServiceResponse(result);
+
+        }
+        JsonTray skillRating = DAO.countryWiseSkillUsage;
+        if (skillRating.has(model_name)) {
+            JSONObject modelName = skillRating.getJSONObject(model_name);
+            if (modelName.has(group_name)) {
+                JSONObject groupName = modelName.getJSONObject(group_name);
+                if (groupName.has(language_name)) {
+                    JSONObject  languageName = groupName.getJSONObject(language_name);
+                    if (languageName.has(skill_name)) {
+                        JSONArray countryWiseSkillUsage = languageName.getJSONArray(skill_name);
+                        result.put("skill_name", skill_name);
+                        result.put("skill_usage", countryWiseSkillUsage);
+                        result.put("accepted", true);
+                        result.put("message", "Country wise skill usage fetched");
+                        return new ServiceResponse(result);
+                    }
+                }
+            }
+        }
+
+        result.put("skill_name", skill_name);
+        result.put("accepted", false);
+        result.put("message", "Skill has not been used yet");
+
+        return new ServiceResponse(result);
+    }
+}

--- a/src/ai/susi/server/api/susi/SusiService.java
+++ b/src/ai/susi/server/api/susi/SusiService.java
@@ -74,6 +74,8 @@ public class SusiService extends AbstractAPIHandler implements APIHandler {
         int timezoneOffset = post.get("timezoneOffset", 0); // minutes, i.e. -60
         double latitude = post.get("latitude", Double.NaN); // i.e. 8.68 
         double longitude = post.get("longitude", Double.NaN); // i.e. 50.11
+        String countryName = post.get("country_name", "");
+        String countryCode = post.get("country_code", "");
         String language = post.get("language", "en");
         String dream = post.get("dream", ""); // an instant dream setting, to be used for permanent dreaming
         String persona = post.get("persona", ""); // an instant dream setting, to be used for permanent dreaming
@@ -153,7 +155,7 @@ public class SusiService extends AbstractAPIHandler implements APIHandler {
         minds.add(DAO.susi);
         
         // answer with built-in intents
-        SusiCognition cognition = new SusiCognition(q, timezoneOffset, latitude, longitude, language, count, user.getIdentity(), minds.toArray(new SusiMind[minds.size()]));
+        SusiCognition cognition = new SusiCognition(q, timezoneOffset, latitude, longitude, countryCode, countryName, language, count, user.getIdentity(), minds.toArray(new SusiMind[minds.size()]));
         if (cognition.getAnswers().size() > 0) try {
             DAO.susi.getMemories().addCognition(user.getIdentity().getClient(), cognition);
         } catch (IOException e) {

--- a/test/ai/susi/mind/SusiTutorialTest.java
+++ b/test/ai/susi/mind/SusiTutorialTest.java
@@ -34,7 +34,7 @@ public class SusiTutorialTest {
     }
     
     public static String susiAnswer(String q, ClientIdentity identity) {
-        SusiCognition cognition = new SusiCognition(q, 0, 0, 0, "en", 1, identity, DAO.susi);
+        SusiCognition cognition = new SusiCognition(q, 0, 0, 0, "", "", "en", 1, identity, DAO.susi);
         JSONObject json = cognition.getJSON();
         try {
             DAO.susi.getMemories().addCognition(identity.getClient(), cognition);


### PR DESCRIPTION
Fixes 
Country wise skill usage analytics #810

Changes: 
1. Created DAO object to store country wise skill usage data in countryWiseSkillUsage.json.
2. Added updateCountryWiseUsageData() function in SusiCognition.java to update country wise skill usage data of the used skills.
3. Created GetCountryWiseSkillUsageService.java to act as API to retrieve country wise skill usage data of any skill.

Endpoint : 
/cms/getCountryWiseSkillUsage.json

Parameters :
- model
- group
- language
- skill


Screenshots for the change: 

countryWiseSkillUsage.json
![image](https://user-images.githubusercontent.com/10573038/41162190-cc086460-6b52-11e8-8962-6a931a710707.png)


Sample API call :
/cms/getCountryWiseSkillUsage.json?model=general&group=Knowledge&language=en&skill=ceo

API response
![image](https://user-images.githubusercontent.com/10573038/41162276-02352fdc-6b53-11e8-8650-6420e9759d3f.png)



