### PR TITLE
Add API to upload images for botbuilder

### DIFF
--- a/src/ai/susi/DAO.java
+++ b/src/ai/susi/DAO.java
@@ -91,7 +91,7 @@ import org.apache.log4j.PatternLayout;
 public class DAO {
 
     private final static String ACCESS_DUMP_FILE_PREFIX = "access_";
-    public  static File conf_dir, bin_dir, html_dir, data_dir, susi_chatlog_dir, susi_skilllog_dir, model_watch_dir, susi_skill_repo, deleted_skill_dir;
+    public  static File conf_dir, bin_dir, html_dir, data_dir, susi_chatlog_dir, susi_skilllog_dir, model_watch_dir, susi_data_watch_dir, susi_skill_repo, deleted_skill_dir;
     public static String conflictsPlaceholder = "%CONFLICTS%";
     private static File external_data, assets, dictionaries;
     private static Settings public_settings, private_settings;
@@ -155,6 +155,7 @@ public class DAO {
             DAO.deleted_skill_dir.mkdirs();
         }
         model_watch_dir = new File(new File(data_dir.getParentFile().getParentFile(), "susi_skill_data"), "models");
+        susi_data_watch_dir = new File(data_dir.getParentFile().getParentFile(), "susi_skill_data");
         susi_skill_repo = new File(data_dir.getParentFile().getParentFile(), "susi_skill_data/.git");
         File susi_generic_skills = new File(data_dir, "generic_skills");
         if (!susi_generic_skills.exists()) susi_generic_skills.mkdirs();

--- a/src/ai/susi/SusiServer.java
+++ b/src/ai/susi/SusiServer.java
@@ -479,6 +479,7 @@ public class SusiServer {
                 GetSkillJsonService.class,
                 GetSkillTxtService.class,
                 CreateSkillService.class,
+                UploadImageService.class,
                 PostSkillJsonService.class,
                 PostSkillTxtService.class,
                 ResendVerificationLinkService.class,

--- a/src/ai/susi/server/api/cms/UploadImageService.java
+++ b/src/ai/susi/server/api/cms/UploadImageService.java
@@ -1,0 +1,187 @@
+package ai.susi.server.api.cms;
+
+import ai.susi.DAO;
+import ai.susi.json.JsonObjectWithDefault;
+import ai.susi.mind.SusiSkill;
+import ai.susi.server.APIHandler;
+import ai.susi.server.AbstractAPIHandler;
+import ai.susi.server.Authentication;
+import ai.susi.server.Authorization;
+import ai.susi.server.ClientCredential;
+import ai.susi.server.ClientIdentity;
+import ai.susi.server.Query;
+import ai.susi.server.ServiceResponse;
+import ai.susi.server.UserRole;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.json.JSONObject;
+
+import javax.imageio.ImageIO;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.MultipartConfig;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
+
+import java.awt.AlphaComposite;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * Created by @hkedia321 on 8/6/18.
+ * This Service uploads an image on the server
+ * Can be tested on :-
+ * http://127.0.0.1:4000/cms/uploadImage.json
+ */
+
+@MultipartConfig(fileSizeThreshold=1024*1024*10,    // 10 MB
+        maxFileSize=1024*1024*50,       // 50 MB
+        maxRequestSize=1024*1024*100)       // 100 MB
+public class UploadImageService extends AbstractAPIHandler implements APIHandler {
+
+    private static final long serialVersionUID = 2461878195432910492L;
+
+    @Override
+    public UserRole getMinimalUserRole() {
+        return UserRole.USER;
+    }
+
+    @Override
+    public JSONObject getDefaultPermissions(UserRole baseUserRole) {
+        return null;
+    }
+
+    @Override
+    public String getAPIPath() {
+        return "/cms/uploadImage.json";
+    }
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+        resp.setHeader("Access-Control-Allow-Origin", "*"); // enable CORS
+        String userEmail = null;
+        JSONObject json = new JSONObject();
+        Part imagePart = req.getPart("image");
+        if (req.getParameter("access_token") != null) {
+            if (imagePart == null) {
+                json.put("accepted", false);
+                json.put("message", "Image not given");
+            } else {
+                InputStream imagePartContent = imagePart.getInputStream();
+
+                String image_name = req.getParameter("image_name");
+
+                if (req.getParameter("access_token") != null) { // access tokens can be used by api calls, somehow the stateless equivalent of sessions for browsers
+                    ClientCredential credential = new ClientCredential(ClientCredential.Type.access_token, req.getParameter("access_token"));
+                    Authentication authentication = DAO.getAuthentication(credential);
+
+                    // check if access_token is valid
+                    if (authentication.getIdentity() != null) {
+                        ClientIdentity identity = authentication.getIdentity();
+                        userEmail = identity.getName();
+                    }
+                }
+                String imagePath = DAO.susi_data_watch_dir + File.separator + "botbuilder" + File.separator + userEmail + File.separator + "images";
+                if (image_name == null) {
+                    // Checking for
+                    json.put("accepted", false);
+                    json.put("message", "The Image name are not given or Image with same name is already present ");
+
+                } else {
+                    // Checking for file existence
+                    json.put("accepted", false);
+
+                    // Reading content for image
+                    Image image = ImageIO.read(imagePartContent);
+                    BufferedImage bi = this.toBufferedImage(image);
+                    // Checks if images directory exists or not. If not then create one
+                    if (!Files.exists(Paths.get(imagePath))) new File(imagePath).mkdirs();
+                    File p = new File(imagePath + File.separator + image_name);
+                    if (p.exists()) p.delete();
+                    ImageIO.write(bi, "jpg", new File(imagePath + File.separator + image_name));
+
+                    //Add to git
+                    try (Git git = DAO.getGit()) {
+                        git.add().addFilepattern(".").call();
+
+                            // commit the changes
+                        DAO.pushCommit(git, "Created image " + image_name, userEmail);
+                        json.put("accepted", true);
+
+                    } catch (IOException | GitAPIException e) {
+                        e.printStackTrace();
+                        json.put("message", "error: " + e.getMessage());
+
+                    }
+                }
+            }
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(json.toString());
+        }
+        else{
+            json.put("message","Access token are not given");
+            json.put("accepted",false);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(json.toString());
+        }
+    }
+    /**
+     * Converts a given Image into a BufferedImage
+     *
+     * @param img The Image to be converted
+     * @return The converted BufferedImage
+     */
+    public static BufferedImage toBufferedImage(Image img)
+    {
+        if (img instanceof BufferedImage)
+        {
+            return (BufferedImage) img;
+        }
+
+    // Create a buffered image with transparency
+        BufferedImage bimage = new BufferedImage(img.getWidth(null), img.getHeight(null), BufferedImage.TYPE_INT_ARGB);
+
+    // Draw the image on to the buffered image
+        Graphics2D bGr = bimage.createGraphics();
+        bGr.drawImage(img, 0, 0, null);
+        bGr.dispose();
+
+    // Return the buffered image
+        return bimage;
+    }
+    /**
+     * Utility method to get file name from HTTP header content-disposition
+     */
+    private static String getFileName(Part part) {
+        String contentDisp = part.getHeader("content-disposition");
+        System.out.println("content-disposition header= "+contentDisp);
+        String[] tokens = contentDisp.split(";");
+        for (String token : tokens) {
+            if (token.trim().startsWith("filename")) {
+                return token.substring(token.indexOf("=") + 2, token.length()-1);
+            }
+        }
+        return "";
+    }
+
+    @Override
+    public ServiceResponse serviceImpl(Query call, HttpServletResponse response, Authorization rights, final JsonObjectWithDefault permissions) {
+
+        return new ServiceResponse("");
+    }
+}
+
+
+
+
+


### PR DESCRIPTION
Fixes #806 

Changes: 
- Add a new route `/cms/uploadImage.json`. This route accepts a post request consisting of three parameters:
  - `access_token`
  - `image_name`
  - `image` (the image file)

It saves the image in `susi_skill_data/botbuilder/<userEmail>/images/<image_name>`.
For example: `susi_skill_data/botbuilder/harshitkedia32@gmail.com/images/logo.png`.
The email address of the user is used to differentiate between images of the same name uploaded by different users. If we store all the images in a single folder and if two users upload different images with the same name (eg. logo.png), then one file would be overwritten by the another. Hence to store them in different places, I am using the user's email id to create different folders.