### PR TITLE
Added API to get device wise skill usage data

### DIFF
--- a/src/ai/susi/DAO.java
+++ b/src/ai/susi/DAO.java
@@ -116,6 +116,7 @@ public class DAO {
     public static JsonTray skillUsage;
     public static JsonTray feedbackSkill;
     public static JsonTray profileDetails;
+    public static JsonTray deviceWiseSkillUsage;
 
 
     static {
@@ -291,6 +292,15 @@ public class DAO {
         skillUsage = new JsonTray(skillUsage_per.toFile(), skillUsage_vol.toFile(), 1000000);
         OS.protectPath(skillUsage_per);
         OS.protectPath(skillUsage_vol);
+
+        // Device wise skill usage
+        Path device_wise_skill_usage_dir = dataPath.resolve("skill_usage");
+        device_wise_skill_usage_dir.toFile().mkdirs();
+        Path deviceWiseSkillUsage_per = device_wise_skill_usage_dir.resolve("deviceWiseSkillUsage.json");
+        Path deviceWiseSkillUsage_vol = device_wise_skill_usage_dir.resolve("deviceWiseSkillUsage_session.json");
+        deviceWiseSkillUsage = new JsonTray(deviceWiseSkillUsage_per.toFile(), deviceWiseSkillUsage_vol.toFile(), 1000000);
+        OS.protectPath(deviceWiseSkillUsage_per);
+        OS.protectPath(deviceWiseSkillUsage_vol);
 
         //Feedback Skill storage
         Path feedbackSkill_per = susi_skill_rating_dir.resolve("feedbackSkill.json");

--- a/src/ai/susi/SusiServer.java
+++ b/src/ai/susi/SusiServer.java
@@ -555,6 +555,9 @@ public class SusiServer {
                 //Skill usage data
                 GetSkillUsageService.class,
 
+                //Get device wise skill usage data
+                GetDeviceWiseSkillUsageService.class,
+
                 //Feedback to skill
                 GetSkillFeedbackService.class,
                 RemoveFeedbackService.class,

--- a/src/ai/susi/mind/SusiCognition.java
+++ b/src/ai/susi/mind/SusiCognition.java
@@ -52,6 +52,7 @@ public class SusiCognition {
             double latitude, double longitude,
             String countryCode, String countryName,
             String languageName,
+            String deviceType,
             int maxcount, ClientIdentity identity,
             final SusiMind... minds) {
         this.json = new JSONObject(true);
@@ -96,7 +97,10 @@ public class SusiCognition {
         // update skill usage data
         if (!dispute.isEmpty()) try {
             List<String> skills = dispute.get(0).getSkills();
-            for (String skill : skills) updateUsageData(skill);
+            for (String skill : skills) {
+                updateUsageData(skill);
+                updateDeviceWiseUsageData(skill, deviceType);
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -108,7 +112,58 @@ public class SusiCognition {
         this.json.put("language", language.name());
     }
 
-    private void updateCountryWiseUsageData(String skillPath, String countryCode, String countryName) {
+    public void updateDeviceWiseUsageData(String skillPath, String deviceType) {
+        String skillInfo[] = skillPath.split("/");
+        String model_name = skillInfo[3];
+        String group_name = skillInfo[4];
+        String language_name = skillInfo[5];
+        String skill_name = skillInfo[6].split("\\.")[0];
+        JsonTray skillUsage = DAO.deviceWiseSkillUsage;
+        JSONObject modelName = new JSONObject();
+        JSONObject groupName = new JSONObject();
+        JSONObject languageName = new JSONObject();
+        JSONArray deviceWiseUsageData =new JSONArray();
+        Boolean deviceExists = false;
+        if (skillUsage.has(model_name)) {
+            modelName = skillUsage.getJSONObject(model_name);
+            if (modelName.has(group_name)) {
+                groupName = modelName.getJSONObject(group_name);
+                if (groupName.has(language_name)) {
+                    languageName = groupName.getJSONObject(language_name);
+                    if (languageName.has(skill_name)) {
+
+                        deviceWiseUsageData = languageName.getJSONArray(skill_name);
+
+                        for (int i = 0; i < deviceWiseUsageData.length(); i++) {
+                            JSONObject deviceUsage = new JSONObject();
+                            deviceUsage = deviceWiseUsageData.getJSONObject(i);
+                            if (deviceUsage.get("device_type").equals(deviceType)) {
+                                deviceUsage.put("count", deviceUsage.getInt("count") + 1);
+                                deviceWiseUsageData.put(i,deviceUsage);
+                                deviceExists = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!deviceExists) {
+            JSONObject deviceUsage = new JSONObject();
+            deviceUsage.put("device_type", deviceType);
+            deviceUsage.put("count", 1);
+            deviceWiseUsageData.put(deviceUsage);
+        }
+
+        languageName.put(skill_name, deviceWiseUsageData);
+        groupName.put(language_name, languageName);
+        modelName.put(group_name, groupName);
+        skillUsage.put(model_name, modelName, true);
+        return;
+    }
+
+    public void updateCountryWiseUsageData(String skillPath, String countryCode, String countryName) {
         String skillInfo[] = skillPath.split("/");
         String model_name = skillInfo[3];
         String group_name = skillInfo[4];

--- a/src/ai/susi/server/api/cms/GetDeviceWiseSkillUsageService.java
+++ b/src/ai/susi/server/api/cms/GetDeviceWiseSkillUsageService.java
@@ -1,0 +1,103 @@
+/**
+ *  GetDeviceWiseSkillUsageService
+ *  Copyright by Anup Kumar Panwar, @anupkumarpanwar
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program in the file lgpl21.txt
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ai.susi.server.api.cms;
+
+import ai.susi.DAO;
+import ai.susi.json.JsonObjectWithDefault;
+import ai.susi.json.JsonTray;
+import ai.susi.mind.SusiSkill;
+import ai.susi.server.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+
+
+/**
+ * This Endpoint accepts 4 parameters. model,group,language,skill
+ * before getting a rating of a skill, the skill must exist in the directory.
+ * http://localhost:4000/cms/getDeviceWiseSkillUsage.json?model=general&group=Knowledge&skill=aboutsusi&language=en
+ */
+public class GetDeviceWiseSkillUsageService extends AbstractAPIHandler implements APIHandler {
+
+
+    private static final long serialVersionUID = 1420414106164188352L;
+
+    @Override
+    public UserRole getMinimalUserRole() {
+        return UserRole.ANONYMOUS;
+    }
+
+    @Override
+    public JSONObject getDefaultPermissions(UserRole baseUserRole) {
+        return null;
+    }
+
+    @Override
+    public String getAPIPath() {
+        return "/cms/getDeviceWiseSkillUsage.json";
+    }
+
+    @Override
+    public ServiceResponse serviceImpl(Query call, HttpServletResponse response, Authorization rights, final JsonObjectWithDefault permissions) {
+
+        String model_name = call.get("model", "general");
+        File model = new File(DAO.model_watch_dir, model_name);
+        String group_name = call.get("group", "Knowledge");
+        File group = new File(model, group_name);
+        String language_name = call.get("language", "en");
+        File language = new File(group, language_name);
+        String skill_name = call.get("skill", null);
+        File skill = SusiSkill.getSkillFileInLanguage(language, skill_name, false);
+
+        JSONObject result = new JSONObject();
+        result.put("accepted", false);
+        if (!skill.exists()) {
+            result.put("message", "Skill does not exist");
+            return new ServiceResponse(result);
+
+        }
+        JsonTray skillRating = DAO.deviceWiseSkillUsage;
+        if (skillRating.has(model_name)) {
+            JSONObject modelName = skillRating.getJSONObject(model_name);
+            if (modelName.has(group_name)) {
+                JSONObject groupName = modelName.getJSONObject(group_name);
+                if (groupName.has(language_name)) {
+                    JSONObject languageName = groupName.getJSONObject(language_name);
+                    if (languageName.has(skill_name)) {
+                        JSONArray deviceWiseSkillUsage = languageName.getJSONArray(skill_name);
+                        result.put("skill_name", skill_name);
+                        result.put("skill_usage", deviceWiseSkillUsage);
+                        result.put("accepted", true);
+                        result.put("message", "Device wise skill usage fetched");
+                        return new ServiceResponse(result);
+                    }
+                }
+            }
+        }
+
+        result.put("skill_name", skill_name);
+        result.put("accepted", false);
+        result.put("message", "Skill has not been used yet");
+
+        return new ServiceResponse(result);
+    }
+}

--- a/src/ai/susi/server/api/susi/SusiService.java
+++ b/src/ai/susi/server/api/susi/SusiService.java
@@ -77,6 +77,7 @@ public class SusiService extends AbstractAPIHandler implements APIHandler {
         String countryName = post.get("country_name", "");
         String countryCode = post.get("country_code", "");
         String language = post.get("language", "en");
+        String deviceType = post.get("device_type", "Others");
         String dream = post.get("dream", ""); // an instant dream setting, to be used for permanent dreaming
         String persona = post.get("persona", ""); // an instant dream setting, to be used for permanent dreaming
 
@@ -155,7 +156,7 @@ public class SusiService extends AbstractAPIHandler implements APIHandler {
         minds.add(DAO.susi);
         
         // answer with built-in intents
-        SusiCognition cognition = new SusiCognition(q, timezoneOffset, latitude, longitude, countryCode, countryName, language, count, user.getIdentity(), minds.toArray(new SusiMind[minds.size()]));
+        SusiCognition cognition = new SusiCognition(q, timezoneOffset, latitude, longitude, countryCode, countryName, language, deviceType, count, user.getIdentity(), minds.toArray(new SusiMind[minds.size()]));
         if (cognition.getAnswers().size() > 0) try {
             DAO.susi.getMemories().addCognition(user.getIdentity().getClient(), cognition);
         } catch (IOException e) {

--- a/test/ai/susi/mind/SusiTutorialTest.java
+++ b/test/ai/susi/mind/SusiTutorialTest.java
@@ -34,7 +34,7 @@ public class SusiTutorialTest {
     }
     
     public static String susiAnswer(String q, ClientIdentity identity) {
-        SusiCognition cognition = new SusiCognition(q, 0, 0, 0, "", "", "en", 1, identity, DAO.susi);
+        SusiCognition cognition = new SusiCognition(q, 0, 0, 0, "", "", "en", "Others",1, identity, DAO.susi);
         JSONObject json = cognition.getJSON();
         try {
             DAO.susi.getMemories().addCognition(identity.getClient(), cognition);


### PR DESCRIPTION
Fixes 
Device wise skill usage stats #818

Changes: 
1. Created DAO object to store device wise skill usage data in deviceWiseSkillUsage.json.
2. Added updateDeviceWiseUsageData() function in SusiCognition.java to update device wise skill usage data of the used skills.
3. Created GetDeviceWiseSkillUsageService.java to act as API to retrieve device wise skill usage data of any skill.

Endpoint : 
/cms/getDeviceWiseSkillUsage.json

Parameters :
- model
- group
- language
- skill


Screenshots for the change: 

deviceWiseSkillUsage.json
![image](https://user-images.githubusercontent.com/10573038/41330059-cbbd69b6-6eee-11e8-8f77-ee9a71f06962.png)


```
Sample API call :
/cms/getDeviceWiseSkillUsage.json?model=general&group=Knowledge&language=en&skill=ceo

```
API response
![image](https://user-images.githubusercontent.com/10573038/41330086-f76c0df6-6eee-11e8-9257-a5f9e7401e80.png)



