### PR TITLE
Fixed minor typo in the installation.sh file

### DIFF
--- a/bin/installation.sh
+++ b/bin/installation.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# If you're looking for the variables, please go to bin/.preload.sh
+# If you're looking for the variables, please go to bin/preload.sh
 
 # Make sure we're on project root
 cd $(dirname $0)/..


### PR DESCRIPTION
Fixes #848

Changes: Corrected `bin/.preload.sh` to `bin/preload.sh`
