### PR TITLE
Added confirmation mails when a user resets/changes his password

### DIFF
--- a/src/ai/susi/server/api/aaa/PasswordChangeService.java
+++ b/src/ai/susi/server/api/aaa/PasswordChangeService.java
@@ -16,6 +16,7 @@
 package ai.susi.server.api.aaa;
 
 import ai.susi.DAO;
+import ai.susi.EmailHandler;
 import ai.susi.json.JsonObjectWithDefault;
 import ai.susi.server.*;
 import ai.susi.tools.TimeoutMatcher;
@@ -110,8 +111,15 @@ public class PasswordChangeService extends AbstractAPIHandler implements APIHand
                 emailauth.remove("passwordHash");
                 emailauth.put("passwordHash", getHash(newpassword, salt));
                 DAO.log("password change for user: " + identity.getName() + " via newpassword from host: " + post.getClientHost());
-                result.put("message", "Your password has been changed!");
-                result.put("accepted", true);
+
+                String subject = "Password Change";
+                try {
+                    EmailHandler.sendEmail(authentication.getIdentity().getName(), subject, "Your password has been changed successfully!");
+                    result.put("message", "Your password has been changed!");
+                    result.put("accepted", true);
+                } catch (Exception e) {
+                    result.put("message", e.getMessage());
+                }
             }
         }
 

--- a/src/ai/susi/server/api/aaa/PasswordResetService.java
+++ b/src/ai/susi/server/api/aaa/PasswordResetService.java
@@ -20,6 +20,7 @@
 package ai.susi.server.api.aaa;
 
 import ai.susi.DAO;
+import ai.susi.EmailHandler;
 import ai.susi.json.JsonObjectWithDefault;
 import ai.susi.server.*;
 import ai.susi.tools.TimeoutMatcher;
@@ -83,8 +84,16 @@ public class PasswordResetService extends AbstractAPIHandler implements APIHandl
 		if (authentication.has("one_time") && authentication.getBoolean("one_time")) {
 			authentication.delete();
 		}
-		result.put("accepted", true);
-		result.put("message", "Your password has been changed!");
+
+		String subject = "Password Reset";
+		try {
+			EmailHandler.sendEmail(authentication.getIdentity().getName(), subject, "Your password has been reset successfully!");
+			result.put("accepted", true);
+			result.put("message", "Your password has been changed!");
+		} catch (Exception e) {
+			result.put("message", e.getMessage());
+		}
+
 		return new ServiceResponse(result);
 	}
 


### PR DESCRIPTION
Fixes #865 

Changes: A confirmation mail will now be sent to the user once the password is reset or changed.
