### PR TITLE
Store private skills in different repository

### DIFF
--- a/src/ai/susi/DAO.java
+++ b/src/ai/susi/DAO.java
@@ -91,7 +91,7 @@ import org.apache.log4j.PatternLayout;
 public class DAO {
 
     private final static String ACCESS_DUMP_FILE_PREFIX = "access_";
-    public  static File conf_dir, bin_dir, html_dir, data_dir, susi_chatlog_dir, susi_skilllog_dir, model_watch_dir, susi_skill_repo, deleted_skill_dir;
+    public  static File conf_dir, bin_dir, html_dir, data_dir, susi_chatlog_dir, susi_skilllog_dir, model_watch_dir, susi_skill_repo, private_skill_watch_dir, susi_private_skill_repo, usi_skill_repo, deleted_skill_dir;
     public static String conflictsPlaceholder = "%CONFLICTS%";
     private static File external_data, assets, dictionaries;
     private static Settings public_settings, private_settings;
@@ -164,7 +164,9 @@ public class DAO {
             DAO.deleted_skill_dir.mkdirs();
         }
         model_watch_dir = new File(new File(data_dir.getParentFile().getParentFile(), "susi_skill_data"), "models");
+        private_skill_watch_dir = new File(new File(data_dir.getParentFile().getParentFile(), "susi_private_skill_data"), "users");
         susi_skill_repo = new File(data_dir.getParentFile().getParentFile(), "susi_skill_data/.git");
+        susi_private_skill_repo = new File(data_dir.getParentFile().getParentFile(), "susi_private_skill_data/.git");
         File susi_generic_skills = new File(data_dir, "generic_skills");
         if (!susi_generic_skills.exists()) susi_generic_skills.mkdirs();
         File susi_generic_skills_media_discovery = new File(susi_generic_skills, "media_discovery");
@@ -522,8 +524,22 @@ public class DAO {
         return repository;
     }
 
+    public static Repository getPrivateRepository() throws IOException {
+        FileRepositoryBuilder builder = new FileRepositoryBuilder();
+        Repository repository = builder.setGitDir((susi_private_skill_repo))
+                .readEnvironment() // scan environment GIT_* variables
+                .findGitDir() // scan up the file system tree
+                .build();
+        return repository;
+    }
+
     public static Git getGit() throws IOException {
         Git git = new Git(getRepository());
+        return git;
+    }
+
+    public static Git getPrivateGit() throws IOException {
+        Git git = new Git(getPrivateRepository());
         return git;
     }
 

--- a/src/ai/susi/mind/SusiSkill.java
+++ b/src/ai/susi/mind/SusiSkill.java
@@ -430,27 +430,31 @@ public class SusiSkill {
         String[] list = languagepath.list();
 
         // first try: the skill name may be same or similar to the skill file name
-        for (String n: list) {
-            if (n.equals(fn) || n.toLowerCase().equals(fn)) {
-                return new File(languagepath, n);
+        if(list !=null && list.length!=0){
+            for (String n: list) {
+                if (n.equals(fn) || n.toLowerCase().equals(fn)) {
+                    return new File(languagepath, n);
+                }
             }
         }
 
         // second try: the skill name may be same or similar to the skill name within the skill description
         // this is costly: we must parse the whole skill file
-        for (String n: list) {
-            if (!n.endsWith(".txt") && !n.endsWith(".ezd")) continue;
-            File f = new File(languagepath, n);
-            try {
-                SusiSkill.ID skillid = new SusiSkill.ID(f);
-                SusiLanguage language = skillid.language();
-                JSONObject json = SusiSkill.readLoTSkill(new BufferedReader(new FileReader(f)), language, Integer.toString(skillid.hashCode()));
-                String sn = json.optString("skill_name");
-                if (sn.equals(skill_name) || sn.toLowerCase().equals(skill_name) || sn.toLowerCase().replace(' ', '_').equals(skill_name)) {
-                    return new File(languagepath, n);
+        if(list !=null && list.length!=0){
+            for (String n: list) {
+                if (!n.endsWith(".txt") && !n.endsWith(".ezd")) continue;
+                File f = new File(languagepath, n);
+                try {
+                    SusiSkill.ID skillid = new SusiSkill.ID(f);
+                    SusiLanguage language = skillid.language();
+                    JSONObject json = SusiSkill.readLoTSkill(new BufferedReader(new FileReader(f)), language, Integer.toString(skillid.hashCode()));
+                    String sn = json.optString("skill_name");
+                    if (sn.equals(skill_name) || sn.toLowerCase().equals(skill_name) || sn.toLowerCase().replace(' ', '_').equals(skill_name)) {
+                        return new File(languagepath, n);
+                    }
+                } catch (JSONException | FileNotFoundException e) {
+                    continue;
                 }
-            } catch (JSONException | FileNotFoundException e) {
-                continue;
             }
         }
 


### PR DESCRIPTION
Fixes #863 

Changes: 
- In `CreateSkillService.java` detect if the client sends an attribute `private`. If it sends, then store the skill in the `susi_private_skill_data` repository. Else store in normally in the `susi_skill_data` repository.
- In `SusiSkill.java` check for empty folder, otherwise it was throwing an error.


Screenshots for the change: 
directory structure in the repository:
```
└── users
    ├── user1id
    │   ├──  custom
    │       ├── Alarms\ and\ Clocks
    ├── user2id
    │   ├──  custom
    │       ├── Alarms\ and\ Clocks
```
Eg: On executing it locally, the private skill was successfully stored in:
![image](https://user-images.githubusercontent.com/17807257/41788214-9ad25196-7668-11e8-9f8d-cfff5c5d307c.png)
