### PR TITLE
Redesign top bar to be similar to susi web client

### DIFF
--- a/html/css/susi.css
+++ b/html/css/susi.css
@@ -13,6 +13,7 @@ body {
   background:#4285f4;
   border-color:#4285f4;
   height: 46px;
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 3px 1px -2px rgba(0,0,0,.2), 0 1px 5px 0 rgba(0,0,0,.12);
 }
 .navbar ul{
   list-style: none;
@@ -38,7 +39,7 @@ code{
   font-size: 25px;
 }
 .susiLogo{
-  height: 46px;
+  height: 45px;
   padding: 10px;
 }
 

--- a/html/index.html
+++ b/html/index.html
@@ -53,9 +53,9 @@
   <style>
     .dropbtn {
       color: white;
-      font-size: 16px;
+      font-size: 18px;
       border: none;
-      width: 35px;
+      width: 17px;
       border-radius: 40px;
       cursor: pointer;
       background: none;
@@ -115,6 +115,10 @@
 
     .optionMenu li a {
       background: none;
+    }
+
+    .optionMenu {
+      margin-top: -1.5px;
     }
 
     .alignRight{


### PR DESCRIPTION
Partially fixes issue #836 

Changes: Redesigned top bar to be similar to susi web client. It's not 100% same because we're using Bootstrap Glyphicon components here but material-ui in SUSI web client. I've made sure that it's almost same though.

Screenshots for the change: 
Before-
Top bar of SUSI Server:
<img width="1145" alt="screen shot 2018-06-22 at 2 01 38 pm" src="https://user-images.githubusercontent.com/31174685/41766538-f3c36eaa-7624-11e8-92e8-6d9c2fed55bd.png">


Now-
1st image is top bar of SUSI Server and 2nd image is top bar of SUSI Web Client
<img width="1145" alt="screen shot 2018-06-22 at 1 58 43 pm" src="https://user-images.githubusercontent.com/31174685/41766372-6f8fedde-7624-11e8-868d-fe1434a1afe8.png">

<img width="1145" alt="screen shot 2018-06-22 at 1 50 54 pm" src="https://user-images.githubusercontent.com/31174685/41766251-1a915e4e-7624-11e8-96aa-73264ea3d8df.png">