### PR TITLE
Change directory structure of private skills to remove model

### DIFF
--- a/src/ai/susi/server/api/cms/CreateSkillService.java
+++ b/src/ai/susi/server/api/cms/CreateSkillService.java
@@ -103,7 +103,7 @@ public class CreateSkillService extends AbstractAPIHandler implements APIHandler
                 }
                 File model = new File(DAO.model_watch_dir, model_name);
                 if(privateSkill != null){
-                    model = new File(private_skill_dir, model_name);
+                    model = private_skill_dir;
                 }
                 String group_name = req.getParameter("group");
                 if (group_name == null) {


### PR DESCRIPTION
Fixes #907 

Changes: 
- remove the `model` parameter for storing private skills. Thus the public and private skills are being stored at the same depth now.

Also, the user is already should be able to create custom "group" since we are accepting the group name from the client. So in the client we can implement the feature of entering custom group name.

Screenshots for the change: 
New structure:
![image](https://user-images.githubusercontent.com/17807257/42064034-34543bca-7b52-11e8-8834-372235acf320.png)

