### PR TITLE
Avoid pushing private skills to origin

### DIFF
--- a/src/ai/susi/DAO.java
+++ b/src/ai/susi/DAO.java
@@ -646,6 +646,34 @@ public class DAO {
         }
     }
 
+    /**
+     * commit user changes to the private skill data repository
+     * @param git
+     * @param commit_message
+     * @param userEmail
+     * @throws IOException
+     */
+    public static void pushCommitPrivate(Git git, String commit_message, String userEmail) throws IOException {
+
+        // fix bad email setting
+        if (userEmail==null || userEmail.isEmpty()) {
+            assert false; // this should not happen
+            userEmail = "anonymous@";
+        }
+
+        try {
+            git.commit()
+                    .setAllowEmpty(false)
+                    .setAll(true)
+                    .setAuthor(new PersonIdent(userEmail,userEmail))
+                    .setMessage(commit_message)
+                    .call();
+
+        } catch (GitAPIException e) {
+            throw new IOException (e.getMessage());
+        }
+    }
+
     private static String getConflictsMailContent(MergeResult mergeResult) throws APIException {
         // get template file
         String result="";

--- a/src/ai/susi/server/api/cms/CreateSkillService.java
+++ b/src/ai/susi/server/api/cms/CreateSkillService.java
@@ -170,7 +170,7 @@ public class CreateSkillService extends AbstractAPIHandler implements APIHandler
                                 git.add().addFilepattern(".").call();
 
                             // commit the changes
-                                DAO.pushCommit(git, "Created " + skill_name, userEmail);
+                                DAO.pushCommitPrivate(git, "Created " + skill_name, userEmail);
                                 json.put("accepted", true);
 
                             } catch (IOException | GitAPIException e) {


### PR DESCRIPTION
Fixes #908 

Changes: 
- make a new method `pushCommitPrivate` in `DAO.java` which will store the private skills only in the local storage and not try to push it in github repository.

Screenshots for the change: 
Before we were getting error because the remote repository didn't exists:
```
{
    "accepted": false,
    "message": "error: origin: not found."
}
```
After:
```
{
    "accepted": true
}
```