### PR TITLE
Added ratings over time

### DIFF
--- a/src/ai/susi/DAO.java
+++ b/src/ai/susi/DAO.java
@@ -120,6 +120,7 @@ public class DAO {
     public static JsonTray deviceWiseSkillUsage;
     public static JsonTray bookmarkSkill;
     public static JsonTray chatbot;
+    public static JsonTray ratingsOverTime;
 
 
     static {
@@ -336,6 +337,13 @@ public class DAO {
         deviceWiseSkillUsage = new JsonTray(deviceWiseSkillUsage_per.toFile(), deviceWiseSkillUsage_vol.toFile(), 1000000);
         OS.protectPath(deviceWiseSkillUsage_per);
         OS.protectPath(deviceWiseSkillUsage_vol);
+
+        // Skill ratings over time
+        Path ratingsOverTime_per = susi_skill_rating_dir.resolve("ratingsOverTime.json");
+        Path ratingsOverTime_vol = susi_skill_rating_dir.resolve("ratingsOverTime_session.json");
+        ratingsOverTime = new JsonTray(ratingsOverTime_per.toFile(), ratingsOverTime_vol.toFile(), 1000000);
+        OS.protectPath(ratingsOverTime_per);
+        OS.protectPath(ratingsOverTime_vol);
 
         // open index
         Path index_dir = dataPath.resolve("index");

--- a/src/ai/susi/SusiServer.java
+++ b/src/ai/susi/SusiServer.java
@@ -568,7 +568,10 @@ public class SusiServer {
                 FeedbackSkillService.class,
 
                 //Bookmark skill
-                BookmarkSkillService.class
+                BookmarkSkillService.class,
+
+                //Skill ratings over time
+                GetRatingsOverTime.class
         };
         for (Class<? extends Servlet> service: services)
             try {

--- a/src/ai/susi/server/api/cms/GetRatingsOverTime.java
+++ b/src/ai/susi/server/api/cms/GetRatingsOverTime.java
@@ -1,5 +1,5 @@
 /**
- *  GetCountryWiseSkillUsageService
+ *  GetRatingsOverTime
  *  Copyright by Anup Kumar Panwar, @anupkumarpanwar
  *
  *  This library is free software; you can redistribute it and/or
@@ -32,11 +32,11 @@ import java.io.File;
 
 
 /**
- * This Endpoint accepts 4 parameters. model,group,language,skill
+ * This Endpoint accepts 4 parameters. model,group,language,skill, duration
  * before getting a rating of a skill, the skill must exist in the directory.
- * http://localhost:4000/cms/getCountryWiseSkillUsage.json?model=general&group=Knowledge&skill=aboutsusi&language=en
+ * http://localhost:4000/cms/getRatingsOverTime.json?model=general&group=Knowledge&skill=aboutsusi&language=en
  */
-public class GetCountryWiseSkillUsageService extends AbstractAPIHandler implements APIHandler {
+public class GetRatingsOverTime extends AbstractAPIHandler implements APIHandler {
 
 
     private static final long serialVersionUID = 1420414106164188352L;
@@ -53,7 +53,7 @@ public class GetCountryWiseSkillUsageService extends AbstractAPIHandler implemen
 
     @Override
     public String getAPIPath() {
-        return "/cms/getCountryWiseSkillUsage.json";
+        return "/cms/getRatingsOverTime.json";
     }
 
     @Override
@@ -75,19 +75,19 @@ public class GetCountryWiseSkillUsageService extends AbstractAPIHandler implemen
             return new ServiceResponse(result);
 
         }
-        JsonTray skillUsage = DAO.countryWiseSkillUsage;
-        if (skillUsage.has(model_name)) {
-            JSONObject modelName = skillUsage.getJSONObject(model_name);
+        JsonTray ratingsOverTime = DAO.ratingsOverTime;
+        if (ratingsOverTime.has(model_name)) {
+            JSONObject modelName = ratingsOverTime.getJSONObject(model_name);
             if (modelName.has(group_name)) {
                 JSONObject groupName = modelName.getJSONObject(group_name);
                 if (groupName.has(language_name)) {
                     JSONObject languageName = groupName.getJSONObject(language_name);
                     if (languageName.has(skill_name)) {
-                        JSONArray countryWiseSkillUsage = languageName.getJSONArray(skill_name);
+                        JSONArray skillRatings = languageName.getJSONArray(skill_name);
                         result.put("skill_name", skill_name);
-                        result.put("skill_usage", countryWiseSkillUsage);
+                        result.put("ratings_over_time", skillRatings);
                         result.put("accepted", true);
-                        result.put("message", "Country wise skill usage fetched");
+                        result.put("message", "Ratings over time fetched");
                         return new ServiceResponse(result);
                     }
                 }
@@ -96,7 +96,7 @@ public class GetCountryWiseSkillUsageService extends AbstractAPIHandler implemen
 
         result.put("skill_name", skill_name);
         result.put("accepted", false);
-        result.put("message", "Skill has not been used yet");
+        result.put("message", "Skill has not been rated yet");
 
         return new ServiceResponse(result);
     }


### PR DESCRIPTION
Fixes #896 
Skill ratings over time

Changes: 
1. Added DAO object to store monthly avg of ratings in /data/skill_rating/ratingsOverTime.json

2. Added API to fetch ratings over time

Endpoint: cms/getRatingsOverTime.json
Parameters:
- model
- group
- language
- skill

Sample API call
```
endpoint

/cms/getRatingsOverTime.json?model=general&group=Novelty%20and%20Humour&language=en&skill=joke
```

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/10573038/42086457-c5ccfc8c-7bb0-11e8-83b8-f5ddbd3ec3d7.png)
