### PR TITLE
Get only locations attribute and correct path

### DIFF
--- a/conf/system_skills/general/en/en_0020_console.json
+++ b/conf/system_skills/general/en/en_0020_console.json
@@ -17,11 +17,11 @@
       "license":"Copyright by urbandictionary.com, http://about.urbandictionary.com/tos"
     },
     "locations":{
-      "example":"http://127.0.0.1:4000/susi/console.json?q=%22SELECT%20*%20FROM%20locations%20WHERE%20query=%27rome%27;%22",
-      "url":"http://api.loklak.org/api/console.json?q=SELECT%20*%20FROM%20locations%20WHERE%20location='$query$';",
+      "example":"http://127.0.0.1:4000/susi/console.json?q=%22SELECT%20location%20FROM%20locations%20WHERE%20query=%27rome%27;%22",
+      "url":"http://api.loklak.org/api/console.json?q=SELECT%20location%20FROM%20locations%20WHERE%20location='$query$';",
       "test":"rome",
       "parser":"json",
-      "path":"$.data",
+      "path":"$.data[0]",
       "license":"Copyright by GeoNames"
     },
     "location-info":{


### PR DESCRIPTION
Fixes #912 

Changes: [Add here what changes were made in this issue and if possible provide links.]

- Only location details selected from api.loklak
 `http://api.loklak.org/api/console.json?q=SELECT%20location%20FROM%20locations%20WHERE%20location=%27singapore%27;_`

- Also Path value is corrected from $.data to $.data[0]
since the API response is of the following type

```
{
  "metadata": {
    "hits": 1,
    "process": "SELECT +?(.*?) +?FROM +?locations +?WHERE +?location ??= ??'(.*?)' ??;",
    "query": "singapore",
    "count": 1
  },
  "data": [{"location": [
    103.85006683126556,
    1.2896698812440377
  ]}],
  "session": {"identity": {
    "type": "host",
    "name": "47.15.226.229",
    "anonymous": true
  }}
}
```

So $.data[0]  -> "location".

Now the above can be used here
https://github.com/fossasia/susi_server/blob/21ca600f7751612add8ef02b25d685e490f4eda4/conf/system_skills/general/en/en_0200_facts_knowledge.json#L13

to get the correct location details which can be passed as `lat`  and `lon` to OpenStreeMap API

 
 