### PR TITLE
Add documentation for storing private skills on local git repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -200,6 +200,17 @@ For your own deployments: The `Susi skill data <https://github.com/fossasia/susi
    
    git clone https://github.com/fossasia/susi_skill_data.git
 
+If you want to create private skills in your local server, you should create a local git repository ``susi_private_skill_data`` alongside Susi server. Then you must create a local git host:
+::
+
+    > cd <above susi home>
+    > mkdir susi_private_skill_data_host
+    > cd susi_private_skill_data_host
+    > git init —bare
+    > cd ../susi_private_skill_data
+    > git remote add origin <path to susi_private_skill_data_host>
+    > git push --set-upstream origin master
+
 *********
 Why should I use Susi AI?
 *********


### PR DESCRIPTION
Fixes #914 

Changes: Add documentation in `Readme` for storing private skills on local git repository


Screenshots for the change: 
![image](https://user-images.githubusercontent.com/17807257/42115746-e2b5a978-7c11-11e8-8554-968bcc642300.png)
