### PR TITLE
Implement top bar UI similar to accounts

### DIFF
--- a/html/css/susi.css
+++ b/html/css/susi.css
@@ -13,7 +13,7 @@ body {
   background:#4285f4;
   border-color:#4285f4;
   height: 46px;
-  box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 3px 1px -2px rgba(0,0,0,.2), 0 1px 5px 0 rgba(0,0,0,.12);
+  box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px;
 }
 .navbar ul{
   list-style: none;
@@ -41,6 +41,8 @@ code{
 .susiLogo{
   height: 45px;
   padding: 10px;
+  margin-top: 1px;
+  margin-left: -1px;
 }
 
 

--- a/html/index.html
+++ b/html/index.html
@@ -118,7 +118,8 @@
     }
 
     .optionMenu {
-      margin-top: -1.5px;
+      margin-top: -4px;
+      margin-right: -6px;
     }
 
     .alignRight{
@@ -144,7 +145,9 @@
   <!--#include file="../data/ssi/custom_body_front.include" -->
   <!--#include file="../ssi/common_body_front.include" -->
   <nav class="navbar navbar-custom  navbar-fixed-top custom-app-bar" style="min-height:46px;">
-    <div class="container-fluid navbar-custom" style="height:46px;">
+    <div class="container-fluid navbar-custom"
+	style="height:46px;box-shadow:0 0 4px rgba(0,0,0,.14),
+		0 4px 8px rgba(0,0,0,.28);">
 
       <div id="">
         <div class="navbar-header">
@@ -170,7 +173,7 @@
 
   <a href="https://github.com/fossasia/susi_server.git"><img style="position:absolute; top:20; right:0; border:0;" src="images/forkme_right_green_007200.png" alt="Fork me on GitHub" title="susi server source code on github"></a>
 
-  <div class="jumbotron" style="padding:100px 0 calc(20%); background-color: white;">
+  <div class="jumbotron" style="height:82vh;min-height:333px; background-color: white;">
     <div class="container">
       <h1><code style="color: #4285f4;background-color: #ebf1fd;"> api.susi.ai</code></h1>
       <h2 style="font-weight: 300; font-size: 25px;">SUSI.AI API Server for Artificial Intelligence Personal Assistants, Robots, Help Desks and Chatbots</h2>


### PR DESCRIPTION
Partially Fixes #836 

Changes: 
- Remove extra spacing between jumbotron and footer and add responsive spacing to avoid vertical scroll for bigger resolutions
- Implement similar top bar as of accounts.susi
- Implement same postion for logo
- Implement same height and shadow.
**Note** The hamburger icon is not same exactly because we're using Bootstrap Glyphicon components on server but material-ui in accounts.

Screenshots for the change: 
Server:
![t1](https://user-images.githubusercontent.com/30981465/42158129-3a55f37a-7e0d-11e8-9a64-b432537d5d9a.png)
Accounts:
![t2](https://user-images.githubusercontent.com/30981465/42158137-3fde8e6a-7e0d-11e8-9cc6-f2fdcb1c1900.png)
