### PR TITLE
Use Google material icons rather than Bootstrap Glyphicons

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -51,9 +51,8 @@
   <!--#include file="../ssi/common_head_back.include" -->
   <!--#include file="../data/ssi/custom_head.include" -->
   <style>
-    .dropbtn {
+    #dropbtn {
       color: white;
-      font-size: 18px;
       border: none;
       width: 17px;
       border-radius: 40px;
@@ -61,15 +60,10 @@
       background: none;
     }
 
-    .dropbtn:hover,
-    .dropbtn:focus {
-      background: none;
-    }
-
-    .dropdown {
-      float: right;
+    #icons {
       position: relative;
-      display: inline-block;
+      color: rgb(117, 117, 117);
+      float: right;
     }
 
     .dropdown-content {
@@ -138,6 +132,7 @@
     
   </style>
   <link rel="stylesheet" href="/css/susi.css" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>
 
 <body style="position: relative; margin-top: 0; min-height: 100; background: #f6f6f6;">
@@ -157,7 +152,7 @@
           </div>
         </div>
         <ul class="nav navbar-nav navbar-right optionMenu">
-          <li><a><span class="	glyphicon glyphicon-option-vertical dropbtn" onclick="myFunction()" ></span> </a></li>
+          <li><a><i class="material-icons" id="dropbtn" onclick="myFunction()">more_vert</i></a></li>
           <div id="navbar" class="dropdown-content">
             <ul></ul>
           </div>
@@ -219,7 +214,7 @@
 
           // Close the dropdown if the user clicks outside of it
           window.onclick = function (event) {
-            if (!event.target.matches('.dropbtn')) {
+            if (!event.target.matches('#dropbtn')) {
 
               var dropdowns = document.getElementsByclass("dropdown-content");
               var i;

--- a/html/js/framework.js
+++ b/html/js/framework.js
@@ -48,22 +48,22 @@ angular.element(document).ready(function () {
         count = count + 1;
       }
       if(name == "Blog" || name == "Account") { // The Blog tab redirects to the loklak blog (http://blog.loklak.net/)
-        liItem += "<a href='"+link+"'>"+name+" <span class='glyphicon glyphicon-user'></span></a></li>";
+        liItem += "<a href='"+link+"'>"+name+" <i class='material-icons' id='icons'>person</i></a></li>";
       }
       else if(name == "API"){
-        liItem += "<a href='"+link+"'>"+name+" <span class='glyphicon glyphicon-asterisk'></span></a></li>";
+        liItem += "<a href='"+link+"'>"+name+" <i class='material-icons' id='icons'>code</i></a></li>";
       }
       else if(name == "Chat"){
-        liItem += "<a href='"+link+"'>"+name+" <span class='glyphicon glyphicon-comment'></span></a></li>";
+        liItem += "<a href='"+link+"'>"+name+" <i class='material-icons' id='icons'>chat</i></a></li>";
       }
       else if(name == "Skills"){
-        liItem += "<a href='"+link+"'>"+name+" <span class='glyphicon glyphicon-th-large'></span></a></li>";
+        liItem += "<a href='"+link+"'>"+name+" <i class='material-icons' id='icons'>dashboard</i></a></li>";
       }
       else if(name == "About"){
-        liItem += "<a href='"+link+"'>"+name+" <span class='glyphicon glyphicon-info-sign'></span></a></li>";
+        liItem += "<a href='"+link+"'>"+name+" <i class='material-icons' id='icons'>info</i></a></li>";
       }
       else if(name == "Login"){
-        liItem += "<a href='"+link+"'>"+name+" <span class='glyphicon glyphicon-user'></span></a></li>";
+        liItem += "<a href='"+link+"'>"+name+" <i class='material-icons' id='icons'>account_circle</i></a></li>";
       }
       else {
         liItem += "<a href='\/"+link+"'>"+name+"</a></li>";


### PR DESCRIPTION
Partially Fixes issue #836

Changes: Replaced Bootstrap Glyphicons with Google material icons and made appropriate changes in CSS.

Screenshots for the change: 

Before:
<img width="25" alt="screen shot 2018-07-02 at 10 35 12 pm" src="https://user-images.githubusercontent.com/31174685/42176909-37d2377c-7e48-11e8-948e-c17ed6e8053e.png">
<img width="139" alt="screen shot 2018-07-02 at 10 30 01 pm" src="https://user-images.githubusercontent.com/31174685/42176864-15041c10-7e48-11e8-859a-c3243ce9af21.png">

After:
<img width="16" alt="screen shot 2018-07-02 at 10 35 16 pm" src="https://user-images.githubusercontent.com/31174685/42176914-3b6d7cac-7e48-11e8-9306-f745d318598f.png">
<img width="141" alt="screen shot 2018-07-02 at 10 29 49 pm" src="https://user-images.githubusercontent.com/31174685/42176872-194a18ce-7e48-11e8-8da6-6a70a2bffe9e.png">


