### PR TITLE
Added a new boolean parameter to skill metadata to mark review status of the skill

### DIFF
--- a/src/ai/susi/mind/SusiSkill.java
+++ b/src/ai/susi/mind/SusiSkill.java
@@ -513,6 +513,7 @@ public class SusiSkill {
         skillMetadata.put("author_email", JSONObject.NULL);
         skillMetadata.put("skill_name", JSONObject.NULL);
         skillMetadata.put("protected", false);
+        skillMetadata.put("reviewed", false);
         skillMetadata.put("terms_of_use", JSONObject.NULL);
         skillMetadata.put("dynamic_content", false);
         skillMetadata.put("examples", JSONObject.NULL);


### PR DESCRIPTION
Fixes #934 

Changes: Added a parameter `reviewed`. It's a boolean which is `true` if the skill has been reviewed and `false` otherwise.