### PR TITLE
Modify user role `BUREAUCRAT` to `SUPERADMIN`

### DIFF
--- a/src/ai/susi/server/UserRole.java
+++ b/src/ai/susi/server/UserRole.java
@@ -34,7 +34,7 @@ public enum UserRole {
     REVIEWER,        // users with special rights for content creation, i.e. moderators
     ACCOUNTCREATOR,  // users with special rights for user account creation
     ADMIN,           // a sysop which can assign accountcreator rights and can assign single access rights to any user. also: delete and restore pages, block and unblock users
-    BUREAUCRAT;      // maximum right, that user is allowed to do everything
+    SUPERADMIN;      // maximum right, that user is allowed to do everything
     
     public String getName() {
     	return this.name().toLowerCase();

--- a/src/ai/susi/server/api/aaa/AuthorizationDemoService.java
+++ b/src/ai/susi/server/api/aaa/AuthorizationDemoService.java
@@ -41,7 +41,7 @@ public class AuthorizationDemoService extends AbstractAPIHandler implements APIH
 		JSONObject result = new JSONObject();
 
 		switch (userRole) {
-            case BUREAUCRAT:
+            case SUPERADMIN:
                 result.put("download_limit", 1000000000);
                 break;
             case ADMIN:

--- a/src/ai/susi/server/api/aaa/ChangeUserRoles.java
+++ b/src/ai/susi/server/api/aaa/ChangeUserRoles.java
@@ -118,8 +118,8 @@ public class ChangeUserRoles extends AbstractAPIHandler implements APIHandler {
                 case "admin":
                     userRole = UserRole.ADMIN;
                     break;
-                case "bureaucrat":
-                    userRole = UserRole.BUREAUCRAT;
+                case "superadmin":
+                    userRole = UserRole.SUPERADMIN;
                     break;
                 default:
                     userRole = null;

--- a/src/ai/susi/server/api/aaa/PublicKeyRegistrationService.java
+++ b/src/ai/susi/server/api/aaa/PublicKeyRegistrationService.java
@@ -86,7 +86,7 @@ public class PublicKeyRegistrationService extends AbstractAPIHandler implements 
 		JSONObject result = new JSONObject();
 
 		switch(baseUserRole){
-			case BUREAUCRAT:
+			case SUPERADMIN:
             case ADMIN:
             case ACCOUNTCREATOR:
             case REVIEWER:

--- a/src/ai/susi/server/api/aaa/ShowAdminService.java
+++ b/src/ai/susi/server/api/aaa/ShowAdminService.java
@@ -40,7 +40,7 @@ public class ShowAdminService extends AbstractAPIHandler implements APIHandler{
         UserRole userRole = rights.getUserRole();
 
         switch (userRole) {
-            case BUREAUCRAT:
+            case SUPERADMIN:
             case ADMIN:
                 json.put("accepted", true);
                 json.put("showAdmin", true);

--- a/src/ai/susi/server/api/aaa/SignUpService.java
+++ b/src/ai/susi/server/api/aaa/SignUpService.java
@@ -52,7 +52,7 @@ public class SignUpService extends AbstractAPIHandler implements APIHandler {
 		result.put("message", "Error: Unable to process you request");
 
 		switch(baseUserRole){
-			case BUREAUCRAT:
+			case SUPERADMIN:
 			case ADMIN:
 			case ACCOUNTCREATOR:
 			case REVIEWER:
@@ -199,7 +199,7 @@ public class SignUpService extends AbstractAPIHandler implements APIHandler {
 		authorized.forEach(client -> keysList.add(client.toString()));
 		String[] keysArray = keysList.toArray(new String[keysList.size()]);
 		if(keysArray.length == 1) {
-			authorization.setUserRole(UserRole.BUREAUCRAT);
+			authorization.setUserRole(UserRole.SUPERADMIN);
 		} else {
 			authorization.setUserRole(UserRole.USER);
 		}

--- a/src/ai/susi/server/api/aaa/UserManagementService.java
+++ b/src/ai/susi/server/api/aaa/UserManagementService.java
@@ -41,7 +41,7 @@ public class UserManagementService extends AbstractAPIHandler implements APIHand
 		JSONObject result = new JSONObject();
 
 		switch(baseUserRole) {
-			case BUREAUCRAT:
+			case SUPERADMIN:
 				result.put("list_users", true);
 				result.put("list_users-roles", true);
 				result.put("edit-all", true);


### PR DESCRIPTION
Fixes #959 

Changes: Replaced all occurrences of `BUREAUCRAT` with `SUPERADMIN`. 
This is as per discussed in the meeting and as outlined in this [spreadsheet](https://docs.google.com/spreadsheets/d/116QIngPEW2QI_p6YEwcj_vQ0dVMTzWZTB-wjWC4s_2s/edit#gid=0).

This is the first step towards implementing all the different user roles as outlined in the above spreadsheet.
