### PR TITLE
Fix bug with modifying skill name

### DIFF
--- a/src/ai/susi/server/api/cms/ModifySkillService.java
+++ b/src/ai/susi/server/api/cms/ModifySkillService.java
@@ -89,8 +89,8 @@ public class ModifySkillService extends AbstractAPIHandler implements APIHandler
     	// debug the call
     	Query query = RemoteAccess.evaluate(call);
         query.initPOST(RemoteAccess.getPostMap(call));
-        logClient(System.currentTimeMillis(), query, null, 0, "init post");    	
-    	
+        logClient(System.currentTimeMillis(), query, null, 0, "init post");
+
     	String userEmail=null;
         String userId = null;
         if (call.getParameter("access_token") != null) { // access tokens can be used by api calls, somehow the stateless equivalent of sessions for browsers
@@ -258,7 +258,7 @@ public class ModifySkillService extends AbstractAPIHandler implements APIHandler
                         new File(modified_language.getPath() + File.separator + "images").mkdirs();
                     }
                     // write new file here
-                    if (!modified_skill.exists() && !Files.exists(new_path)) {
+                    if (!modified_skill.exists()) {
                         skill.delete();
                         try (FileWriter newSkillFile = new FileWriter(modified_skill)) {
                             newSkillFile.write(content);
@@ -337,7 +337,7 @@ public class ModifySkillService extends AbstractAPIHandler implements APIHandler
                 resp.getWriter().write(json.toString());
             } else {
                 JSONObject json = new JSONObject();
-                json.put("message", "Bad parameter call");
+                json.put("message", "Skill doesn't exists");
                 json.put("accepted", false);
                 resp.setContentType("application/json");
                 resp.setCharacterEncoding("UTF-8");


### PR DESCRIPTION
Fixes #957 

Changes: 
- Remove the condition which made the modifying skill feature work only when both the skill name and image was changed. Now it works also when only the skill name is changed and the image is not changed.
- Change the error message to more meaningful "Skill doesn't exists" when the user tries to edit skill which doesn't exists. This message is directly displayed to the user thus the message like "Bad parameter call" wouldn't make sense for the user.

Screenshots for the change: 
Before: (when modify a skill by changing its name only)
![image](https://user-images.githubusercontent.com/17807257/42658800-0629932e-8644-11e8-8670-65f051eca9a7.png)
Now: (when modify a skill by changing its name only)
![image](https://user-images.githubusercontent.com/17807257/42658885-446f3706-8644-11e8-93f0-7f03e21b7c4d.png)


