### PR TITLE
Fixes #964: Set the 'author' attribute correctly in skill metadata

### DIFF
--- a/src/ai/susi/mind/SusiSkill.java
+++ b/src/ai/susi/mind/SusiSkill.java
@@ -311,7 +311,7 @@ public class SusiSkill {
                     if (line.substring(thenpos + 1).trim().equalsIgnoreCase("yes")) protectedSkill=true;
                     json.put("protected",protectedSkill);
                 }
-                if (line.startsWith("::author") && (!line.startsWith("::author_url")) && (thenpos = line.indexOf(' ')) > 0) {
+                if (line.startsWith("::author") && (!line.startsWith("::author_url")) && (!line.startsWith("::author_email")) && (thenpos = line.indexOf(' ')) > 0) {
                     authorName = line.substring(thenpos + 1).trim();
                     if(authorName.length() > 0)
                         json.put("author",authorName);


### PR DESCRIPTION
Fixes #964 

Changes: [Add here what changes were made in this issue and if possible provide links.]
* Handle the case when `author_email` appears before `author` in skill file
