### PR TITLE
Modify user role `ACCOUNTCREATOR` to `OPERATOR`

### DIFF
--- a/src/ai/susi/server/UserRole.java
+++ b/src/ai/susi/server/UserRole.java
@@ -32,8 +32,8 @@ public enum UserRole {
     ANONYMOUS,       // a person, everyone who is not logged in
     USER,            // users who have logged in
     REVIEWER,        // users with special rights for content creation, i.e. moderators
-    ACCOUNTCREATOR,  // users with special rights for user account creation
-    ADMIN,           // a sysop which can assign accountcreator rights and can assign single access rights to any user. also: delete and restore pages, block and unblock users
+    OPERATOR,        // users with special rights for user account creation
+    ADMIN,           // a sysop which can assign operator rights and can assign single access rights to any user. also: delete and restore pages, block and unblock users
     SUPERADMIN;      // maximum right, that user is allowed to do everything
     
     public String getName() {

--- a/src/ai/susi/server/api/aaa/AuthorizationDemoService.java
+++ b/src/ai/susi/server/api/aaa/AuthorizationDemoService.java
@@ -47,7 +47,7 @@ public class AuthorizationDemoService extends AbstractAPIHandler implements APIH
             case ADMIN:
                 result.put("download_limit", 100000);
                 break;
-			case ACCOUNTCREATOR:
+			case OPERATOR:
 				result.put("download_limit", 10000);
 				break;
             case REVIEWER:

--- a/src/ai/susi/server/api/aaa/ChangeUserRoles.java
+++ b/src/ai/susi/server/api/aaa/ChangeUserRoles.java
@@ -112,8 +112,8 @@ public class ChangeUserRoles extends AbstractAPIHandler implements APIHandler {
                 case "reviewer":
                     userRole = UserRole.REVIEWER;
                     break;
-                case "accountcreator":
-                    userRole = UserRole.ACCOUNTCREATOR;
+                case "operator":
+                    userRole = UserRole.OPERATOR;
                     break;
                 case "admin":
                     userRole = UserRole.ADMIN;

--- a/src/ai/susi/server/api/aaa/PublicKeyRegistrationService.java
+++ b/src/ai/susi/server/api/aaa/PublicKeyRegistrationService.java
@@ -88,7 +88,7 @@ public class PublicKeyRegistrationService extends AbstractAPIHandler implements 
 		switch(baseUserRole){
 			case SUPERADMIN:
             case ADMIN:
-            case ACCOUNTCREATOR:
+            case OPERATOR:
             case REVIEWER:
 			case USER:
 				result.put("self", true);

--- a/src/ai/susi/server/api/aaa/ShowAdminService.java
+++ b/src/ai/susi/server/api/aaa/ShowAdminService.java
@@ -49,7 +49,7 @@ public class ShowAdminService extends AbstractAPIHandler implements APIHandler{
             case ANONYMOUS:
             case USER:
             case REVIEWER:
-            case ACCOUNTCREATOR:
+            case OPERATOR:
             default:
                 json.put("accepted", true);
                 json.put("showAdmin", false);

--- a/src/ai/susi/server/api/aaa/SignUpService.java
+++ b/src/ai/susi/server/api/aaa/SignUpService.java
@@ -54,7 +54,7 @@ public class SignUpService extends AbstractAPIHandler implements APIHandler {
 		switch(baseUserRole){
 			case SUPERADMIN:
 			case ADMIN:
-			case ACCOUNTCREATOR:
+			case OPERATOR:
 			case REVIEWER:
 			case USER:
 				result.put("register", true); // allow to register new users (this bypasses email verification and activation)

--- a/src/ai/susi/server/api/aaa/UserManagementService.java
+++ b/src/ai/susi/server/api/aaa/UserManagementService.java
@@ -33,7 +33,7 @@ public class UserManagementService extends AbstractAPIHandler implements APIHand
 
 	@Override
 	public UserRole getMinimalUserRole() {
-		return UserRole.ACCOUNTCREATOR;
+		return UserRole.OPERATOR;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #979 

Changes: Replaced all occurrences of `ACCOUNTCREATOR` with `OPERATOR`. 
This is as per discussed in the meeting and as outlined in this [spreadsheet](https://docs.google.com/spreadsheets/d/116QIngPEW2QI_p6YEwcj_vQ0dVMTzWZTB-wjWC4s_2s/edit#gid=0).

This is the first step towards implementing all the different features specific to `OPERATOR` as outlined in the above spreadsheet.
