### PR TITLE
Modified ShowAdminService.java to allow OPERATOR access to Admin section

### DIFF
--- a/src/ai/susi/server/api/aaa/ShowAdminService.java
+++ b/src/ai/susi/server/api/aaa/ShowAdminService.java
@@ -42,6 +42,7 @@ public class ShowAdminService extends AbstractAPIHandler implements APIHandler{
         switch (userRole) {
             case SUPERADMIN:
             case ADMIN:
+            case OPERATOR:
                 json.put("accepted", true);
                 json.put("showAdmin", true);
                 break;
@@ -49,7 +50,6 @@ public class ShowAdminService extends AbstractAPIHandler implements APIHandler{
             case ANONYMOUS:
             case USER:
             case REVIEWER:
-            case OPERATOR:
             default:
                 json.put("accepted", true);
                 json.put("showAdmin", false);


### PR DESCRIPTION
Fixes #981 

Changes: Modified `ShowAdminService.java` to allow `OPERATOR` access to Admin section. 
This is as per outlined in this [spreadsheet](https://docs.google.com/spreadsheets/d/116QIngPEW2QI_p6YEwcj_vQ0dVMTzWZTB-wjWC4s_2s/edit#gid=0).