### PR TITLE
Fixed wrong JSON response issue in LoginService when access token is not provided

### DIFF
--- a/src/ai/susi/server/api/aaa/LoginService.java
+++ b/src/ai/susi/server/api/aaa/LoginService.java
@@ -101,6 +101,9 @@ public class LoginService extends AbstractAPIHandler implements APIHandler {
         boolean delete = post.get("delete", false);
 		if (logout || delete) {	// logout if requested
 
+			if(post.get("access_token") == null || authorization.getIdentity() == null) {
+				throw new APIException(400, "Bad access token.");
+			}
 			// invalidate session
 			post.getRequest().getSession().invalidate();
 


### PR DESCRIPTION
Fixes #1002 

Changes: Fixed wrong JSON response issue in LoginService when access token is not provided. Now exception is thrown when access token is not provided.

For example, on this API call: `http://127.0.0.1:4000/aaa/login.json?delete=true`,

Before:
The following JSON response was received:
```
{
  "accepted": true,
  "message": "Account deletion successful",
  "session": {"identity": {
    "type": "host",
    "name": "127.0.0.1_d94a4646",
    "anonymous": true
  }}
}
```

Now:
Exception is thrown.