### PR TITLE
Added a new boolean parameter to skill metadata to mark edit status of the skill

### DIFF
--- a/src/ai/susi/mind/SusiSkill.java
+++ b/src/ai/susi/mind/SusiSkill.java
@@ -519,6 +519,7 @@ public class SusiSkill {
         skillMetadata.put("skill_name", JSONObject.NULL);
         skillMetadata.put("protected", false);
         skillMetadata.put("reviewed", false);
+        skillMetadata.put("editable", true);
         skillMetadata.put("terms_of_use", JSONObject.NULL);
         skillMetadata.put("dynamic_content", false);
         skillMetadata.put("examples", JSONObject.NULL);
@@ -547,7 +548,8 @@ public class SusiSkill {
                 skillMetadata.put("dynamic_content", skill.getDynamicContent());
                 skillMetadata.put("examples", skill.getExamples() ==null ? JSONObject.NULL: skill.getExamples());
                 skillMetadata.put("skill_rating", getSkillRating(model, group, language, skillname));
-                skillMetadata.put("reviewed", getSkillStatus(model, group, language, skillname));
+                skillMetadata.put("reviewed", getSkillReviewStatus(model, group, language, skillname));
+                skillMetadata.put("editable", getSkillEditStatus(model, group, language, skillname));
                 skillMetadata.put("usage_count", getSkillUsage(model, group, language, skillname, duration));
                 skillMetadata.put("skill_tag", skillname);
 
@@ -624,7 +626,7 @@ public class SusiSkill {
         return newRating;
     }
 
-    public static boolean getSkillStatus(String model, String group, String language, String skillname) {
+    public static boolean getSkillReviewStatus(String model, String group, String language, String skillname) {
         // skill status
         JsonTray skillStatus = DAO.skillStatus;
         if (skillStatus.has(model)) {
@@ -644,6 +646,28 @@ public class SusiSkill {
             }
         }
         return false;
+    }
+
+    public static boolean getSkillEditStatus(String model, String group, String language, String skillname) {
+        // skill status
+        JsonTray skillStatus = DAO.skillStatus;
+        if (skillStatus.has(model)) {
+            JSONObject modelName = skillStatus.getJSONObject(model);
+            if (modelName.has(group)) {
+                JSONObject groupName = modelName.getJSONObject(group);
+                if (groupName.has(language)) {
+                    JSONObject languageName = groupName.getJSONObject(language);
+                    if (languageName.has(skillname)) {
+                        JSONObject skillName = languageName.getJSONObject(skillname);
+
+                        if (skillName.has("editable")) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        return true;
     }
 
     public static int getSkillUsage(String model, String group, String language, String skillname, int duration) {

--- a/src/ai/susi/server/api/cms/ListSkillService.java
+++ b/src/ai/susi/server/api/cms/ListSkillService.java
@@ -170,7 +170,7 @@ public class ListSkillService extends AbstractAPIHandler implements APIHandler {
                         JSONObject skillMetadata = SusiSkill.getSkillMetadata(model_name, temp_group_name, language_name, skill_name, duration);
 
                         if(reviewed.equals("true")) {
-                            if(SusiSkill.getSkillStatus(model_name, temp_group_name, language_name, skill_name)) {
+                            if(SusiSkill.getSkillReviewStatus(model_name, temp_group_name, language_name, skill_name)) {
                                 jsonArray.put(skillMetadata);
                                 skillObject.put(skill_name, skillMetadata);
                             }
@@ -197,7 +197,7 @@ public class ListSkillService extends AbstractAPIHandler implements APIHandler {
                     JSONObject skillMetadata = SusiSkill.getSkillMetadata(model_name, group_name, language_name, skill_name, duration);
 
                     if(reviewed.equals("true")) {
-                        if(SusiSkill.getSkillStatus(model_name, group_name, language_name, skill_name)) {
+                        if(SusiSkill.getSkillReviewStatus(model_name, group_name, language_name, skill_name)) {
                             jsonArray.put(skillMetadata);
                             skillObject.put(skill_name, skillMetadata);
                         }


### PR DESCRIPTION
Fixes #1001 

Changes: Added a boolean parameter `editable` to the skill metadata for each skill. It's a boolean, which if `false`, would indicate that the Skill is not editable.

Structure of the skillStatus.json file:
```
{
   "general":{
      "Knowledge":{
         "en":{
            "Synonyms":{
               "editable":false
            },
            "Antonyms":{
               "editable":false
            }
         }
      }
   }
}
```

Response of `http://127.0.0.1:4000/cms/getSkillMetadata.json?model=general&group=Knowledge&language=en&skill=antonyms`:
```
{
  "skill_metadata": {
    "model": "general",
    "group": "Knowledge",
    "language": "en",
    "developer_privacy_policy": null,
    "descriptions": "A skill that returns the antonyms for a word",
    "image": "images/antonyms.png",
    "author": "akshat jain",
    "author_url": "https://github.com/Akshat-Jain",
    "author_email": null,
    "skill_name": "Antonyms",
    "protected": false,
    "reviewed": false,
    "editable": false,
    "terms_of_use": null,
    "dynamic_content": true,
    "examples": ["Antonym of happy"],
    "skill_rating": {
      "negative": "0",
      "bookmark_count": 0,
      "positive": "0",
      "stars": {
        "one_star": 0,
        "four_star": 0,
        "five_star": 0,
        "total_star": 0,
        "three_star": 0,
        "avg_star": 0,
        "two_star": 0
      },
      "feedback_count": 0
    },
    "usage_count": 0,
    "skill_tag": "Antonyms",
    "creationTime": "2018-06-28T04:31:15Z",
    "lastAccessTime": "2018-07-07T06:23:03Z",
    "lastModifiedTime": "2018-07-06T11:00:54Z"
  },
  "accepted": true,
  "message": "Success: Fetched Skill's Metadata",
  "session": {"identity": {
    "type": "host",
    "name": "127.0.0.1_d94a4646",
    "anonymous": true
  }}
}
```

Next steps would be to make an API to allow `OPERATOR` or higher userroles to allow changing the editable status of any skill, by making changes in the `skillStatus.json` file.
This is as per outlined in this [spreadsheet](https://docs.google.com/spreadsheets/d/116QIngPEW2QI_p6YEwcj_vQ0dVMTzWZTB-wjWC4s_2s/edit#gid=1053849824).
