### PR TITLE
Removed lowercasing of author name before putting it in skill metadata

### DIFF
--- a/src/ai/susi/mind/SusiSkill.java
+++ b/src/ai/susi/mind/SusiSkill.java
@@ -738,12 +738,7 @@ public class SusiSkill {
     }
 
     public String getAuthor() {
-        if (author!=null) {
-            return author.toLowerCase();
-        }
-        else {
-            return author;
-        }
+        return author;
     }
 
     public String getAuthorURL() {


### PR DESCRIPTION
Fixes #1014 

Changes: Put the exact author name in the skill metadata as in the skill code, without lowercasing it. 