### PR TITLE
Prevented changing of user role to ANONYMOUS

### DIFF
--- a/src/ai/susi/server/api/aaa/ChangeUserRoles.java
+++ b/src/ai/susi/server/api/aaa/ChangeUserRoles.java
@@ -104,8 +104,7 @@ public class ChangeUserRoles extends AbstractAPIHandler implements APIHandler {
                     userRole = UserRole.BOT;
                     break;
                 case "anonymous":
-                    userRole = UserRole.ANONYMOUS;
-                    break;
+                    throw new APIException(400, "Cannot change user role to anonymous.");
                 case "user":
                     userRole = UserRole.USER;
                     break;


### PR DESCRIPTION
Fixes #1017 

Changes: Now, trying to change user role to `ANONYMOUS` would throw exception, instead of changing it to `ANONYMOUS` which shouldn't be possible.
