### PR TITLE
Modify API to fetch private skills based on new json structure

### DIFF
--- a/src/ai/susi/server/api/cms/ListSkillService.java
+++ b/src/ai/susi/server/api/cms/ListSkillService.java
@@ -68,33 +68,49 @@ public class ListSkillService extends AbstractAPIHandler implements APIHandler {
                 JSONObject result = new JSONObject();
                 JSONObject userObject = new JSONObject();
                 JSONArray botDetailsArray = new JSONArray();
-                JSONArray chatbotArray = new JSONArray();
 
-                for(String user_id : chatbot.keys())
+                userObject = chatbot.getJSONObject(userId);
+                JSONObject groupObject = new JSONObject();
+                JSONObject languageObject = new JSONObject();
+
+                Iterator groupNames = userObject.keys();
+                List<String> groupnameKeysList = new ArrayList<String>();
+
+                while(groupNames.hasNext()) {
+                    String key = (String) groupNames.next();
+                    groupnameKeysList.add(key);
+                }
+
+                for(String group_name : groupnameKeysList)
                 {
-                    if(user_id.equals(userId)) {
-                        userObject = chatbot.getJSONObject(user_id);
-                        Iterator chatbotDetails = userObject.keys();
-                        List<String> chatbotDetailsKeysList = new ArrayList<String>();
-                        while(chatbotDetails.hasNext()) {
-                            String key = (String) chatbotDetails.next();
-                            chatbotDetailsKeysList.add(key);
+                    groupObject = userObject.getJSONObject(group_name);
+                    Iterator languageNames = groupObject.keys();
+                    List<String> languagenameKeysList = new ArrayList<String>();
+
+                    while(languageNames.hasNext()) {
+                        String key = (String) languageNames.next();
+                        languagenameKeysList.add(key);
+                    }
+
+                    for(String language_name : languagenameKeysList)
+                    {
+                        languageObject = groupObject.getJSONObject(language_name);
+                        Iterator skillNames = languageObject.keys();
+                        List<String> skillnamesKeysList = new ArrayList<String>();
+
+                        while(skillNames.hasNext()) {
+                            String key = (String) skillNames.next();
+                            skillnamesKeysList.add(key);
                         }
 
-                        for(String chatbot_name : chatbotDetailsKeysList)
+                        for(String skill_name : skillnamesKeysList)
                         {
-                            chatbotArray = userObject.getJSONArray(chatbot_name);
-                            for(int i=0; i<chatbotArray.length(); i++) {
-                                String name = chatbotArray.getJSONObject(i).get("name").toString();
-                                String language = chatbotArray.getJSONObject(i).get("language").toString();
-                                String group = chatbotArray.getJSONObject(i).get("group").toString();
-                                JSONObject botDetails = new JSONObject();
-                                botDetails.put("name", name);
-                                botDetails.put("language", language);
-                                botDetails.put("group", group);
-                                botDetailsArray.put(botDetails);
-                                result.put("chatbots", botDetailsArray);
-                            }
+                            JSONObject botDetails = languageObject.getJSONObject(skill_name);
+                            botDetails.put("name", skill_name);
+                            botDetails.put("language", language_name);
+                            botDetails.put("group", group_name);
+                            botDetailsArray.put(botDetails);
+                            result.put("chatbots", botDetailsArray);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #1025 

Changes: 
- Since the json structure of `chatbot.json` is being changed by PR #1021, this PR makes changes in the `ListSkillService.java` file to retrieve private skill bots according to the new json format.

Screenshots for the change: 
If the `chatbot.json` file contains:
```
{
  "17a70987d09c33e6f56fe05dca6e3d27": {"Knowledge": {
    "en": {
      "test2new1": {
        "design": {
          "botIconColor": "#000000"
        },
        "configure": {
          "sites_enabled": "website1.com, website2.com",
          "sites_disabled": "website3.com"
        },
        "timestamp": "2018-07-20 01:04:39.571"
      }
    },
    "ga": {"test2new112": {
      "design": {
        "botIconColor": "#000000"
      },
      "configure": {
        "sites_enabled": "website1.com, website2.com",
        "sites_disabled": "website3.com"
      },
      "timestamp": "2018-07-20 01:40:13.581"
    }}
  }}
}
```
The response of the `getSkillList.json` API is:
```
{
  "session": {"identity": {
    "type": "email",
    "name": "harshit2@gmail.com",
    "anonymous": false
  }},
  "chatbots": [
    {
      "design": {
        "botIconColor": "#000000"
      },
      "name": "test2new1",
      "language": "en",
      "configure": {
        "sites_enabled": "website1.com, website2.com",
        "sites_disabled": "website3.com"
      },
      "timestamp": "2018-07-20 01:04:39.571",
      "group": "Knowledge"
    },
    {
      "design": {
        "botIconColor": "#000000"
      },
      "name": "test2new112",
      "language": "ga",
      "configure": {
        "sites_enabled": "website1.com, website2.com",
        "sites_disabled": "website3.com"
      },
      "timestamp": "2018-07-20 01:40:13.581",
      "group": "Knowledge"
    }
  ],
  "accepted": true,
  "message": "All chatbots of user fetched."
}
```
