### PR TITLE
Fix issue with skillsToBeDeleted.json not returning list of deleted skills

### DIFF
--- a/src/ai/susi/server/api/cms/SkillsToBeDeleted.java
+++ b/src/ai/susi/server/api/cms/SkillsToBeDeleted.java
@@ -23,8 +23,7 @@ import ai.susi.DAO;
 import ai.susi.json.JsonObjectWithDefault;
 import ai.susi.server.*;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.DirectoryFileFilter;
-import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -62,9 +61,9 @@ public class SkillsToBeDeleted extends AbstractAPIHandler implements APIHandler 
         JSONObject json = new JSONObject();
 
         Collection files = FileUtils.listFiles(
-                DAO.deleted_skill_dir,
-                new RegexFileFilter("^(.txt)"),
-                DirectoryFileFilter.DIRECTORY
+                new File(DAO.deleted_skill_dir.getPath()),
+                TrueFileFilter.INSTANCE,
+                TrueFileFilter.TRUE
         );
 
         JSONArray jsArray = new JSONArray(files);


### PR DESCRIPTION
Fixes #1029 

Changes:
Before:
 ```
{
  "skills": [],
  "session": {"identity": {
    "type": "email",
    "name": "coolcooder@gmail.com",
    "anonymous": false
  }},
  "accepted": true,
  "message": "Success: Fetched skill list"
}
```
Now:
```
{
  "skills": [
    "data/deleted_skill_dir/models/general/Utilities/en/domain_check.txt",
    "data/deleted_skill_dir/models/general/Knowledge/en/quotes.txt"
  ],
  "session": {"identity": {
    "type": "email",
    "name": "coolcooder@gmail.com",
    "anonymous": false
  }},
  "accepted": true,
  "message": "Success: Fetched skill list"
}
```

Screenshots for the change: 
