### PR TITLE
Modify getImage API to return images for public and private skills

### DIFF
--- a/src/ai/susi/server/api/cms/GetImageServlet.java
+++ b/src/ai/susi/server/api/cms/GetImageServlet.java
@@ -39,21 +39,59 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 /**
- This Servlet gives a API Endpoint to return image stored in local storage given its full path 
- Can be tested on http://127.0.0.1:4000/cms/getImage.png?image=963e84467b92c0916b27d157b1d45328/1529692996805_susi icon.png
+ This Servlet gives a API Endpoint to return image
+ To get a public skill's image
+ http://localhost:4000/cms/getImage.png?model=general&language=en&group=Food%20and%20Drink&image=images/cooking_guide.png
+    
+ To get a private skill's image
+ http://localhost:4000/cms/getImage.png?access_token=k30RWlpTKvKM3TUiwi7E5a2bgtjJQa&language=en&group=Knowledge&image=images/susi%20icon.png
+
+ To get image stored in local storage
+ http://localhost:4000/cms/getImage.png?image=963e84467b92c0916b27d157b1d45328/1529692996805_susi icon.png
  */
-public class GetImageServlet extends HttpServlet {
+ public class GetImageServlet extends HttpServlet {
 
     private static final long serialVersionUID = 628253297031919192L;
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        
+
         Query post = RemoteAccess.evaluate(request);
-        String image_path = post.get("image","");
-        File imageFile = new File(DAO.data_dir  + File.separator + "image_uploads" + File.separator+ image_path);
-        if (!imageFile.exists()) {response.sendError(503, "image does not exist"); return;}
-        String file = image_path.substring(image_path.indexOf("/")+1);
+        File imageFile = null;
+        String file = "";
+
+        if (post.get("group","") != "" && post.get("language","") != "" && post.get("image","") != "") {
+            String group = post.get("group","");
+            String language = post.get("language","");
+            String image = post.get("image","");
+            file = image;
+            // for public skill
+            if (post.get("model","") != "") {
+                String model = post.get("model","");
+                imageFile = new File(DAO.model_watch_dir  + File.separator + model + File.separator + group + File.separator + language + File.separator + image);
+            } 
+            // for private skill
+            if (post.get("access_token","") != "") {
+                String userId = "";
+                ClientCredential credential = new ClientCredential(ClientCredential.Type.access_token, post.get("access_token",""));
+                Authentication authentication = DAO.getAuthentication(credential);
+                // check if access_token is valid
+                if (authentication.getIdentity() != null) {
+                    ClientIdentity identity = authentication.getIdentity();
+                    userId = identity.getUuid();
+                }
+                imageFile = new File(DAO.private_skill_watch_dir  + File.separator + userId + File.separator + group + File.separator + language + File.separator + image);
+            }
+        }
+        else if (post.get("image","") != "") {
+        // for custom user's images
+            String image_path = post.get("image","");
+            file = image_path.substring(image_path.indexOf("/")+1);
+            imageFile = new File(DAO.data_dir  + File.separator + "image_uploads" + File.separator+ image_path);
+        }
+
+        if (imageFile == null || !imageFile.exists()) {response.sendError(503, "image does not exist"); return;}
+        
         ByteArrayOutputStream data = new ByteArrayOutputStream();
         byte[] b = new byte[2048];
         InputStream is = new BufferedInputStream(new FileInputStream(imageFile));


### PR DESCRIPTION
Fixes #1031 
Fixes #998 

Changes: 
In `GetImageServlet.java` file, make three conditions to fetch image for "public skill", "private skill", or from "local storage" depending on the parameters provided by the client.
- For fetching image of a "public skill" the client has to provide the following parameters:
  - `model`
  - `language`
  - `group`
  - `image`

 Example: `http://localhost:4000/cms/getImage.png?model=general&language=en&group=Food%20and%20Drink&image=images/cooking_guide.png`

- For fetching image of a "private skill" the client has to provide the following parameters:
  - `access_token`
  - `language`
  - `group`
  - `image`

 Example: `http://localhost:4000/cms/getImage.png?access_token=k30RWlpTKvKM3TUiwi7E5a2bgtjJQa&language=en&group=Knowledge&image=images/susi%20icon.png`

- For fetching image from "local storage" the client has to provide the following parameters:
  - `image`

 Example: `http://localhost:4000/cms/getImage.png?image=963e84467b92c0916b27d157b1d45328/1529692996805_susi icon.png`
