### PR TITLE
Fixed incorrect sorting on home page

### DIFF
--- a/src/ai/susi/server/api/cms/SkillMetricsDataService.java
+++ b/src/ai/susi/server/api/cms/SkillMetricsDataService.java
@@ -172,12 +172,12 @@ public class SkillMetricsDataService extends AbstractAPIHandler implements APIHa
                 try {
                     valA = a.opt("skill_rating");
                     valB = b.opt("skill_rating");
-                    if (valA == null || !((valA instanceof JSONObject))) valA = new JSONObject().put("stars", new JSONObject().put("avg_star", 0.0f));
-                    if (valB == null || !((valB instanceof JSONObject))) valB = new JSONObject().put("stars", new JSONObject().put("avg_star", 0.0f));
+                    if (valA == null || !(valA instanceof JSONObject)) valA = new JSONObject().put("stars", new JSONObject().put("avg_star", 0.0f));
+                    if (valB == null || !(valB instanceof JSONObject)) valB = new JSONObject().put("stars", new JSONObject().put("avg_star", 0.0f));
                     
                     result = Float.compare(
-                            ((JSONObject) valA).getJSONObject("stars").getFloat("avg_star"),
-                            ((JSONObject) valB).getJSONObject("stars").getFloat("avg_star"));
+                            ((JSONObject) valB).getJSONObject("stars").getFloat("avg_star"),
+                            ((JSONObject) valA).getJSONObject("stars").getFloat("avg_star"));
                 } catch (JSONException e) {
                     e.printStackTrace();
                 }
@@ -220,9 +220,13 @@ public class SkillMetricsDataService extends AbstractAPIHandler implements APIHa
                 try {
                     valA = a.opt("skill_rating");
                     valB = b.opt("skill_rating");
-                    if (valA == null || !(valA instanceof Integer)) valA = 0;
-                    if (valB == null || !(valB instanceof Integer)) valB = 0;
-                    result = Integer.compare((Integer) valB, (Integer) valA);
+                    if (valA == null || !(valA instanceof JSONObject) || ((JSONObject) valA).opt("feedback_count") == null) valA = new JSONObject().put("feedback_count", 0);
+                    if (valB == null || !(valB instanceof JSONObject) || ((JSONObject) valB).opt("feedback_count") == null) valB = new JSONObject().put("feedback_count", 0);
+
+                    result = Integer.compare(
+                            ((JSONObject) valB).getInt("feedback_count"),
+                            ((JSONObject) valA).getInt("feedback_count")
+                    );
                 } catch (JSONException e) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
Fixes #1040 

Changes: 
The rating was earlier sorting the skills in ascending order, so reversed it.
Handled the case of feedback_count is not available.

Screenshots for the change: 
NA