### PR TITLE
Add new parameters to structure of chatbot.json for Configure settings

### DIFF
--- a/src/ai/susi/server/api/cms/CreateSkillService.java
+++ b/src/ai/susi/server/api/cms/CreateSkillService.java
@@ -319,16 +319,31 @@ public class CreateSkillService extends AbstractAPIHandler implements APIHandler
                       if(value.length() > 0)
                           designObject.put("botIconImage",value);
                   }
-                  else if (line.startsWith("::sites_enabled") && (thenpos = line.indexOf(' ')) > 0) {
-                      String value = line.substring(thenpos + 1).trim();
-                      if(value.length() > 0)
-                          configObject.put("sites_enabled",value);
-                  }
-                  else if (line.startsWith("::sites_disabled") && (thenpos = line.indexOf(' ')) > 0) {
-                      String value = line.substring(thenpos + 1).trim();
-                      if(value.length() > 0)
-                          configObject.put("sites_disabled",value);
-                  }
+                  else if (line.startsWith("::allow_bot_only_on_own_sites") && (thenpos = line.indexOf(' ')) > 0) {
+                    Boolean value = false;
+                    if(line.substring(thenpos + 1).trim().equalsIgnoreCase("yes")) value = true;
+                    configObject.put("allow_bot_only_on_own_sites",value);
+                }
+                else if (line.startsWith("::allowed_sites") && (thenpos = line.indexOf(' ')) > 0) {
+                    String value = line.substring(thenpos + 1).trim();
+                    if(value.length() > 0)
+                        configObject.put("allowed_sites",value);
+                }
+                else if (line.startsWith("::enable_default_skills") && (thenpos = line.indexOf(' ')) > 0) {
+                    Boolean value = true;
+                    if(line.substring(thenpos + 1).trim().equalsIgnoreCase("no")) value = false;
+                    configObject.put("enable_default_skills",value);
+                }
+                else if (line.startsWith("::enable_bot_in_my_devices") && (thenpos = line.indexOf(' ')) > 0) {
+                    Boolean value = false;
+                    if(line.substring(thenpos + 1).trim().equalsIgnoreCase("yes")) value = true;
+                    configObject.put("enable_bot_in_my_devices",value);
+                }
+                else if (line.startsWith("::enable_bot_for_other_users") && (thenpos = line.indexOf(' ')) > 0) {
+                    Boolean value = false;
+                    if(line.substring(thenpos + 1).trim().equalsIgnoreCase("yes")) value = true;
+                    configObject.put("enable_bot_for_other_users",value);
+                }
                 }
               }
           } catch (IOException e) {


### PR DESCRIPTION
Fixes #1038 

Changes: Added new parameters to structure of chatbot.json for configure settings as per the new changes in configure tab of bot wizard. The configure code currently looks this:
<img width="792" alt="screen shot 2018-07-25 at 7 09 59 pm" src="https://user-images.githubusercontent.com/31174685/43204517-b190fe60-903e-11e8-94c4-377c9d04ecc4.png">

After creating the private skill with the appropriate parameters and `allow_bot_only_on_own_sites` as `no`, the following data was successfully stored in `data/chatbot/chatbot.json` file:
```
  "abc": {
    "design": {
      "botIconColor": "#000000",
      "userMessageTextColor": "#7d6262",
      "botMessageBoxBackground": "#f8f8f8",
      "userMessageBoxBackground": "#b8c4d2",
      "botMessageTextColor": "#455a64",
      "bodyBackground": "#b54848"
    },
    "configure": {
      "enable_bot_in_my_devices": false,
      "enable_default_skills": true,
      "allow_bot_only_on_own_sites": false,
      "enable_bot_for_other_users": false
    },
    "timestamp": "2018-07-25 19:05:02.66"
  },
```
After creating the private skill with the appropriate parameters and `allow_bot_only_on_own_sites` as `yes` and adding sample sites in `allowed_sites`, the following data was successfully stored in `data/chatbot/chatbot.json` file:
```
  "abc123": {
    "design": {
      "botIconColor": "#000000",
      "userMessageTextColor": "#7d6262",
      "botMessageBoxBackground": "#f8f8f8",
      "userMessageBoxBackground": "#b8c4d2",
      "botMessageTextColor": "#455a64",
      "bodyBackground": "#b54848"
    },
    "configure": {
      "enable_bot_in_my_devices": false,
      "allowed_sites": "abc.com, def.com",
      "enable_default_skills": true,
      "allow_bot_only_on_own_sites": true,
      "enable_bot_for_other_users": false
    },
    "timestamp": "2018-07-25 19:05:29.811"
  },
```
