### PR TITLE
Added a boolean parameter to the skill metadata to identify if a skill is staff pick or not

### DIFF
--- a/src/ai/susi/mind/SusiSkill.java
+++ b/src/ai/susi/mind/SusiSkill.java
@@ -522,6 +522,7 @@ public class SusiSkill {
         skillMetadata.put("protected", false);
         skillMetadata.put("reviewed", false);
         skillMetadata.put("editable", true);
+        skillMetadata.put("staffPick", false);
         skillMetadata.put("terms_of_use", JSONObject.NULL);
         skillMetadata.put("dynamic_content", false);
         skillMetadata.put("examples", JSONObject.NULL);
@@ -552,6 +553,7 @@ public class SusiSkill {
                 skillMetadata.put("skill_rating", getSkillRating(model, group, language, skillname));
                 skillMetadata.put("reviewed", getSkillReviewStatus(model, group, language, skillname));
                 skillMetadata.put("editable", getSkillEditStatus(model, group, language, skillname));
+                skillMetadata.put("staffPick", isStaffPick(model, group, language, skillname));
                 skillMetadata.put("usage_count", getSkillUsage(model, group, language, skillname, duration));
                 skillMetadata.put("skill_tag", skillname);
 
@@ -817,6 +819,28 @@ public class SusiSkill {
             }
         }
         return true;
+    }
+
+    public static boolean isStaffPick(String model, String group, String language, String skillname) {
+        // return true if skill is a staff pick
+        JsonTray skillStatus = DAO.skillStatus;
+        if (skillStatus.has(model)) {
+            JSONObject modelName = skillStatus.getJSONObject(model);
+            if (modelName.has(group)) {
+                JSONObject groupName = modelName.getJSONObject(group);
+                if (groupName.has(language)) {
+                    JSONObject languageName = groupName.getJSONObject(language);
+                    if (languageName.has(skillname)) {
+                        JSONObject skillName = languageName.getJSONObject(skillname);
+
+                        if (skillName.has("staffPick")) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     public static int getSkillUsage(String model, String group, String language, String skillname, int duration) {


### PR DESCRIPTION
Fixes #1033 

Changes: Added a boolean parameter `staffPick` to the skill metadata to identify if a skill is staff pick or not.

Structure of the skillStatus.json file:
```
{"general": {"Knowledge": {"en": {
  "Anime_Suggestions": {
    "editable": false,
    "staffPick": true
  }
}}}}
```

Response of `http://127.0.0.1:4000/cms/getSkillMetadata.json?model=general&group=Knowledge&language=en&skill=Anime%20Suggestions`:
```
{
  "skill_metadata": {
    "model": "general",
    "group": "Knowledge",
    "language": "en",
    "developer_privacy_policy": null,
    "descriptions": "A skill to suggest animes",
    "image": "images/anime.png",
    "author": "Anshuman",
    "author_url": "https://github.com/anshumanv",
    "author_email": "anshu.av97@gmail.com",
    "skill_name": "Anime Suggestions",
    "protected": false,
    "reviewed": false,
    "editable": false,
    "staffPick": true,
    "terms_of_use": null,
    "dynamic_content": false,
    "examples": ["Suggest an anime"],
    "skill_rating": {
      "negative": "0",
      "bookmark_count": 0,
      "positive": "0",
      "stars": {
        "one_star": 0,
        "four_star": 0,
        "five_star": 0,
        "total_star": 0,
        "three_star": 0,
        "avg_star": 0,
        "two_star": 0
      },
      "feedback_count": 0
    },
    "usage_count": 0,
    "skill_tag": "Anime_Suggestions",
    "creationTime": "2018-07-19T13:35:32Z",
    "lastAccessTime": "2018-07-25T13:35:32Z",
    "lastModifiedTime": "2018-07-19T13:35:32Z"
  },
  "accepted": true,
  "message": "Success: Fetched Skill's Metadata",
  "session": {"identity": {
    "type": "host",
    "name": "127.0.0.1_d94a4646",
    "anonymous": true
  }}
}
```

Next steps would be to make an API to allow `OPERATOR` or higher user roles to make the state of a skill as `Staff Pick`, by making changes in the `skillStatus.json` file.