### PR TITLE
Modify DeleteSkillService to support deletion of private skill

### DIFF
--- a/src/ai/susi/server/api/cms/DeleteSkillService.java
+++ b/src/ai/susi/server/api/cms/DeleteSkillService.java
@@ -6,6 +6,7 @@ import ai.susi.mind.SusiSkill;
 import ai.susi.server.*;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import ai.susi.json.JsonTray;
 import org.json.JSONObject;
 
 import javax.servlet.http.HttpServletResponse;
@@ -16,11 +17,13 @@ import java.io.IOException;
 /**
  * Created by chetankaushik on 06/06/17.
  * This Service deletes a skill as per given query.
- * http://localhost:4000/cms/deleteSkill.txt?model=general&group=Knowledge&language=en&skill=whois
+ * http://localhost:4000/cms/deleteSkill.json?access_token=ANecfA1GjP4Bkgv4PwjL0OAW4kODzW&model=general&group=Knowledge&language=en&skill=whois
  * When someone deletes a skill then it will move a folder delete_skills_dir.
  * When a file is moved to the delete_skills_dir its last modified date is changed to the current date.
  * Then in the caretaker there is a function which checks for files which are older than 30 days by checking the last modified date.
  * If there is any file which is older than 30 days then it deletes them.
+ * This API can be used to delete a private skill as well, by sending private=1 parameter
+ * http://localhost:4000/cms/deleteSkill.json?access_token=ANecfA1GjP4Bkgv4PwjL0OAW4kODzW&private=1&group=Knowledge&language=en&skill=myskill
  */
 
 public class DeleteSkillService extends AbstractAPIHandler implements APIHandler {
@@ -29,7 +32,7 @@ public class DeleteSkillService extends AbstractAPIHandler implements APIHandler
 
     @Override
     public UserRole getMinimalUserRole() {
-        return UserRole.ADMIN;
+        return UserRole.USER;
     }
 
     @Override
@@ -45,21 +48,57 @@ public class DeleteSkillService extends AbstractAPIHandler implements APIHandler
     @Override
     public ServiceResponse serviceImpl(Query call, HttpServletResponse response, Authorization rights, final JsonObjectWithDefault permissions) {
 
+        JSONObject json = new JSONObject(true);
+        json.put("accepted", false);
         String model_name = call.get("model", "general");
+        String access_token = call.get("access_token", null);
+        String privateSkill = call.get("private", null);
+        String userId = null;
+        // extract userid and check for user role
+        ClientCredential credential = new ClientCredential(ClientCredential.Type.access_token, access_token);
+        Authentication authentication = DAO.getAuthentication(credential);
+        // check if access_token is valid
+        if (authentication.getIdentity() != null) {
+            ClientIdentity identity = authentication.getIdentity();
+            Authorization authorization = DAO.getAuthorization(identity);
+            UserRole userRole = authorization.getUserRole();
+            userId = identity.getUuid();
+            if (privateSkill == null) {
+                // if deleting a public skill, the person should be admin or superadmin
+                if (!(userRole.getName().equals("admin") || userRole.getName().equals("superadmin"))) {
+                    json.put("message", "Must be admin to delete a skill");
+                    return new ServiceResponse(json);
+                }
+            } 
+        }
+        else {
+        // invalid access token provided
+        json.put("message", "Invalid access token");
+        return new ServiceResponse(json);
+        }
+        
         File model = new File(DAO.model_watch_dir, model_name);
+        if (privateSkill != null) {
+            model = new File(DAO.private_skill_watch_dir, userId);
+        }
         String group_name = call.get("group", "Knowledge");
         File group = new File(model, group_name);
         String language_name = call.get("language", "en");
         File language = new File(group, language_name);
         String skill_name = call.get("skill", "whois");
         File skill = SusiSkill.getSkillFileInLanguage(language, skill_name, false);
-        JSONObject json = new JSONObject(true);
-        json.put("accepted", false);
+        
+        
         if(!DAO.deleted_skill_dir.exists()){
             DAO.deleted_skill_dir.mkdirs();
         }
         String path = skill.getPath();
-        path = path.replace(DAO.model_watch_dir.getPath(),"");
+        if (privateSkill != null) {
+            path = path.replace(DAO.private_skill_watch_dir.getPath(),"");
+        }
+        else {
+            path = path.replace(DAO.model_watch_dir.getPath(),"");
+        }
 
         if (skill.exists()) {
             File file = new File(DAO.deleted_skill_dir.getPath()+path);
@@ -73,24 +112,57 @@ public class DeleteSkillService extends AbstractAPIHandler implements APIHandler
             }
 
             json.put("message","Deleted "+ skill_name);
-
+            json.put("accepted", true);
             //Add to git
-            try (Git git = DAO.getGit()) {
-                git.add()
-                        .setUpdate(true)
-                        .addFilepattern(".")
-                        .call();
+            if (privateSkill != null) {
+                deleteChatbot(userId, group_name, language_name, skill_name);
+                try (Git git = DAO.getPrivateGit()) {
+                    git.add()
+                    .setUpdate(true)
+                    .addFilepattern(".")
+                    .call();
                 // and then commit the changes
-                DAO.pushCommit(git, "Deleted " + skill_name, !rights.getIdentity().isAnonymous() ? rights.getIdentity().getName() : "anonymous@");
-                json.put("accepted", true);
-                json.put("message", "Deleted " + skill_name);
-            } catch (IOException | GitAPIException e) {
-                e.printStackTrace();
+                    DAO.pushCommit(git, "Deleted " + skill_name, !rights.getIdentity().isAnonymous() ? rights.getIdentity().getName() : "anonymous@");
+                    json.put("message", "Deleted " + skill_name);
+                } catch (IOException | GitAPIException e) {
+                    e.printStackTrace();
+                }
+            }
+            else {
+                try (Git git = DAO.getGit()) {
+                    git.add()
+                    .setUpdate(true)
+                    .addFilepattern(".")
+                    .call();
+                // and then commit the changes
+                    DAO.pushCommit(git, "Deleted " + skill_name, !rights.getIdentity().isAnonymous() ? rights.getIdentity().getName() : "anonymous@");
+                    json.put("message", "Deleted " + skill_name);
+                } catch (IOException | GitAPIException e) {
+                    e.printStackTrace();
+                }
             }
         } else {
             json.put("message", "Cannot find '" + skill + "' ('" + skill.getAbsolutePath() + "')");
         }
         return new ServiceResponse(json);
+    }
+
+    private static void deleteChatbot(String userId,String group,String language,String skill) {
+        JsonTray chatbot = DAO.chatbot;
+        JSONObject userIdName = new JSONObject();
+        JSONObject groupName = new JSONObject();
+        JSONObject languageName = new JSONObject();
+        if (chatbot.has(userId)) {
+            userIdName = chatbot.getJSONObject(userId);
+            if (userIdName.has(group)) {
+                groupName = userIdName.getJSONObject(group);
+                if (groupName.has(language)) {
+                    languageName = groupName.getJSONObject(language);
+                    languageName.remove(skill);
+                    chatbot.commit();
+                }
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #1046 

Changes: 
- detect a parameter `private` from the client. If this parameter is set, then delete the private skill from the appropriate git folder and also remove it from `chatbot.json` file.
- previously, the base user role for the API was `ADMIN`. I changed it to `USER` because a normal user can delete their own private skill, therefore the API should be accessible to them. Also, I checked for the user role to be `ADMIN` or `SUPERADMIN` inside `serviceImpl()` function when the request is for deleting a public skill.

Example request: `http://localhost:4000/cms/deleteSkill.json?access_token=ANecfA1GjP4Bkgv4PwjL0OAW4kODzW&private=1&group=Knowledge&language=en&skill=myskill`

Response on successfully deleting the private skill:
```
{
  "accepted": true,
  "message": "Deleted testing",
  "session": {"identity": {
    "type": "email",
    "name": "harshit1@gmail.com",
    "anonymous": false
  }}
}
```
