### PR TITLE
Add user's uuid in login API's response after successful login

### DIFF
--- a/src/ai/susi/server/api/aaa/LoginService.java
+++ b/src/ai/susi/server/api/aaa/LoginService.java
@@ -215,6 +215,7 @@ public class LoginService extends AbstractAPIHandler implements APIHandler {
 					if(valid_seconds == -1) result.put("valid_seconds", "forever");
 					else result.put("valid_seconds", valid_seconds);
 
+					result.put("uuid", identity.getUuid());
 					result.put("access_token", token);
 					result.put("accepted", true);
 


### PR DESCRIPTION
Fixes #1058 

Changes: 
- return the user's uuid in the login API after successful login.

This uuid will be stored in the client's cookie and can be used when an API requires the client to send the userId (For example the `http://127.0.0.1:4000/cms/getSkillMetadata.json?userid=17a70987d09c33e6f56fe05dca6e3d27&group=Knowledge&language=en&skill=testnew` API to fetch skill's design and configuration settings)

Screenshots for the change: 
Response after login:
```
{
  "accepted": true,
  "valid_seconds": 604800,
  "uuid": "963e84467b92c0916b27d157b1d45328",
  "access_token": "wImd3xC9d3P9MLfmNqGNziwJexcZdC",
  "message": "You are logged in as harshit1@gmail.com",
  "session": {"identity": {
    "type": "host",
    "name": "0:0:0:0:0:0:0:1_41b6e914",
    "anonymous": true
  }}
}

```