### PR TITLE
Fixed issues with GetSkillsByAuthor not returning any Skills

### DIFF
--- a/src/ai/susi/server/api/cms/GetSkillsByAuthor.java
+++ b/src/ai/susi/server/api/cms/GetSkillsByAuthor.java
@@ -64,7 +64,7 @@ public class GetSkillsByAuthor extends AbstractAPIHandler implements APIHandler 
         if(author_email == null) {
             for (Map.Entry<SusiSkill.ID, SusiSkill> entry : DAO.susi.getSkillMetadata().entrySet()) {
                 SusiSkill.ID skill = entry.getKey();
-                if ((entry.getValue().getAuthor()!=null) && entry.getValue().getAuthor().contains(author.toLowerCase())) {
+                if ((entry.getValue().getAuthor()!=null) && entry.getValue().getAuthor().contains(author)) {
                     result.put(result.length()+"",skill);
                 }
             }


### PR DESCRIPTION
Fixes #1065 

Changes: Fixed issues with `/cms/getSkillsByAuthor.json` not returning any Skills when author name is used as the query parameter. 
This will also fix the empty list issues on clicking author name on Skill CMS.
