### PR TITLE
Modified ChangeSkillStatusService to allow Admins and higher user roles to mark any skill as staff pick

### DIFF
--- a/src/ai/susi/server/api/cms/ChangeSkillStatusService.java
+++ b/src/ai/susi/server/api/cms/ChangeSkillStatusService.java
@@ -29,7 +29,7 @@ import org.json.JSONObject;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * This endpoint allows Admin and higher userroles to change review status of any skill
+ * This endpoint allows Admin and higher userroles to change status of any skill
  * http://127.0.0.1:4000/cms/changeSkillStatus.json?model=general&group=Knowledge&language=en&skill=aboutsusi&reviewed=true&access_token=zdasIagg71NF9S2Wu060ZxrRdHeFAx
  */
 
@@ -60,6 +60,7 @@ public class ChangeSkillStatusService extends AbstractAPIHandler implements APIH
         String skill_name = call.get("skill", null);
         String reviewed = call.get("reviewed", null);
         String editable = call.get("editable", null);
+        String staffPick = call.get("staffPick", null);
 
         if (authorization.getIdentity() == null) {
             throw new APIException(422, "Bad access token.");
@@ -73,6 +74,9 @@ public class ChangeSkillStatusService extends AbstractAPIHandler implements APIH
         else if (editable != null && !(editable.equals("true") || editable.equals("false"))) {
             throw new APIException(400, "Bad service call, invalid arguments.");
         }
+        else if (staffPick != null && !(staffPick.equals("true") || staffPick.equals("false"))) {
+            throw new APIException(400, "Bad service call, invalid arguments.");
+        }
 
         JSONObject result = new JSONObject();
         JsonTray skillStatus = DAO.skillStatus;
@@ -81,13 +85,16 @@ public class ChangeSkillStatusService extends AbstractAPIHandler implements APIH
         JSONObject languageName = new JSONObject();
         JSONObject skillName = new JSONObject();
 
-        if( ((reviewed != null && reviewed.equals("true")) || (editable != null && editable.equals("false"))) ) {
+        if( (reviewed != null && reviewed.equals("true")) || (editable != null && editable.equals("false")) || (staffPick != null && staffPick.equals("true")) ) {
             JSONObject skill_status = new JSONObject();
             if(reviewed != null && reviewed.equals("true")) {
                 skill_status.put("reviewed", true);
             }
             if(editable != null && editable.equals("false")) {
                 skill_status.put("editable", false);
+            }
+            if(staffPick != null && staffPick.equals("true")) {
+                skill_status.put("staffPick", true);
             }
             if (skillStatus.has(model_name)) {
                 modelName = skillStatus.getJSONObject(model_name);
@@ -111,6 +118,13 @@ public class ChangeSkillStatusService extends AbstractAPIHandler implements APIH
                             }
                             else if(editable != null && editable.equals("true")) {
                                 skillName.remove("editable");
+                            }
+
+                            if(staffPick != null && staffPick.equals("true")) {
+                                skillName.put("staffPick", true);
+                            }
+                            else if(staffPick != null && staffPick.equals("false")) {
+                                skillName.remove("staffPick");
                             }
                             skillStatus.commit();
                             result.put("accepted", true);
@@ -143,6 +157,9 @@ public class ChangeSkillStatusService extends AbstractAPIHandler implements APIH
                             }
                             if(editable != null && editable.equals("true")) {
                                 skillName.remove("editable");
+                            }
+                            if(staffPick != null && staffPick.equals("false")) {
+                                skillName.remove("staffPick");
                             }
                             if(skillName.length() == 0) {
                                 languageName.remove(skill_name);


### PR DESCRIPTION
Fixes #1072 

Changes: Modified `/cms/changeSkillStatus.json` to allow Admin and higher user roles to mark any skill as `Staff Pick`.

For example, the following API call `http://127.0.0.1:4000/cms/changeSkillStatus.json?model=general&group=Knowledge&language=en&skill=acronyms&staffPick=true&access_token=MpSUjzQ01qDhOfOIZ5NLiBxB4GfEpm` adds the skill `acronyms` to the list of staff picks in the `skillStatus.json` file. The JSON response of this API call is:

```
{
  "session": {"identity": {
    "type": "email",
    "name": "akjn11@gmail.com",
    "anonymous": false
  }},
  "accepted": true,
  "message": "Skill status changed successfully."
}
```

This is also reflected in the skill metadata of the Skill `acronyms` where `staffPick` is set to `true`. The API call `http://localhost:4000/cms/getSkillMetadata.json?model=general&group=Knowledge&language=en&skill=acronyms` gives the following JSON output:

```
{
  "skill_metadata": {
    "model": "general",
    "group": "Knowledge",
    "language": "en",
    "developer_privacy_policy": null,
    "descriptions": "Tells us about acronyms. An abbreviation formed from the initial letters of other words and pronounced as a word",
    "image": "images/acronyms.png",
    "author": "Madhav Rathi",
    "author_url": "https://www.github.com/madhavrathi",
    "author_email": null,
    "skill_name": "Acronyms",
    "protected": false,
    "reviewed": true,
    "editable": false,
    "staffPick": true,
    "terms_of_use": null,
    "dynamic_content": true,
    "examples": ["Acronym of NASA"],
    "skill_rating": {
      "negative": "0",
      "bookmark_count": 0,
      "positive": "0",
      "stars": {
        "one_star": 0,
        "four_star": 0,
        "five_star": 0,
        "total_star": 0,
        "three_star": 0,
        "avg_star": 0,
        "two_star": 0
      },
      "feedback_count": 0
    },
    "usage_count": 0,
    "skill_tag": "acronyms",
    "creationTime": "2018-06-28T04:31:15Z",
    "lastAccessTime": "2018-07-26T09:35:54Z",
    "lastModifiedTime": "2018-06-28T04:31:15Z"
  },
  "accepted": true,
  "message": "Success: Fetched Skill's Metadata",
  "session": {"identity": {
    "type": "host",
    "name": "0:0:0:0:0:0:0:1_d94a4646",
    "anonymous": true
  }}
}
```

I've also modified it in a way to allow combined calls like: 
`http://127.0.0.1:4000/cms/changeSkillStatus.json?model=general&group=Knowledge&language=en&skill=acronyms&reviewed=true&editable=false&staffPick=true&access_token=zdasIagg71JK9SB7u060ZxrRdHeFAx`. 
This would allow changing the review status, edit status and also the staff pick status of a Skill in the same API call.
