### PR TITLE
Implement API to fetch API keys

### DIFF
--- a/src/ai/susi/SusiServer.java
+++ b/src/ai/susi/SusiServer.java
@@ -455,7 +455,8 @@ public class SusiServer {
                 // aaa services
                 StatusService.class,
                 AppsService.class,
-                ApiKeysService.class, 
+                ApiKeysService.class,
+                GetApiKeys.class,
                 AuthorizationDemoService.class,
                 LoginService.class,
                 PasswordRecoveryService.class,

--- a/src/ai/susi/server/api/aaa/ApiKeysService.java
+++ b/src/ai/susi/server/api/aaa/ApiKeysService.java
@@ -73,19 +73,24 @@ public class ApiKeysService extends AbstractAPIHandler implements APIHandler {
             throw new APIException(422, "Bad Request. No parameter present");
         }
 
-        JsonTray apiKeys = DAO.apiKeys;
-        JSONObject result = new JSONObject();
-        boolean deleteKey = call.get("deleteKey", false);
         String keyName = call.get("keyName", null);
         String keyValue = call.get("keyValue", null);
         String type = call.get("type", "public");
+        boolean deleteKey = call.get("deleteKey", false);
+        JsonTray apiKeys = DAO.apiKeys;
+        JSONObject result = new JSONObject();
+        JSONObject keys = new JSONObject();
+
+        if (apiKeys.has(type)) {
+            keys = apiKeys.getJSONObject(type);
+        }
 
 	if(!deleteKey){
             try {
                JSONObject api = new JSONObject();
                api.put("value", keyValue);
-               api.put("type", type);
-               apiKeys.put(keyName, api, true);
+               keys.put(keyName, api);
+               apiKeys.put(type, keys, true);
                result.put("accepted", true);
                result.put("message", "Added new API key " + call.get("keyName") + " successfully !");
                return new ServiceResponse(result);
@@ -94,7 +99,8 @@ public class ApiKeysService extends AbstractAPIHandler implements APIHandler {
             }
 	} else {
             try {
-               apiKeys.remove(keyName);
+               keys.remove(keyName);
+               apiKeys.put(type, keys, true);
                result.put("accepted", true);
                result.put("message", "Removed API key " + call.get("keyName") + " successfully !");
                return new ServiceResponse(result);

--- a/src/ai/susi/server/api/aaa/GetApiKeys.java
+++ b/src/ai/susi/server/api/aaa/GetApiKeys.java
@@ -1,0 +1,83 @@
+/**
+ *  GetApiKeys
+ *  Copyright by Praduman @PrP-11 on 29/07/18.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program in the file lgpl21.txt
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ai.susi.server.api.aaa;
+
+import ai.susi.DAO;
+import ai.susi.json.JsonObjectWithDefault;
+import ai.susi.json.JsonTray;
+import ai.susi.server.*;
+import org.json.JSONObject;
+import java.lang.Object;
+
+import javax.servlet.http.HttpServletResponse;
+import ai.susi.server.APIException;
+import ai.susi.server.APIHandler;
+import ai.susi.server.AbstractAPIHandler;
+import ai.susi.server.Query;
+import ai.susi.server.ServiceResponse;
+import ai.susi.server.UserRole;
+
+/**
+ * This Servlet gives a API Endpoint to fetch different API keys used by SUSI.
+ * It requires user role to be ANONYMOUS or above ANONYMOUS
+ * example:
+ * http://localhost:4000/aaa/getApiKeys.json
+ */
+
+public class GetApiKeys extends AbstractAPIHandler implements APIHandler {
+
+    @Override
+    public String getAPIPath() {
+        return "/aaa/getApiKeys.json";
+    }
+
+    @Override
+    public UserRole getMinimalUserRole() {
+        return UserRole.ANONYMOUS;
+    }
+
+    @Override
+    public JSONObject getDefaultPermissions(UserRole baseUserRole) {
+        return null;
+    }
+
+    @Override
+    public ServiceResponse serviceImpl(Query call, HttpServletResponse response, Authorization rights, final JsonObjectWithDefault permissions) throws APIException {
+
+        JsonTray apiKeys = DAO.apiKeys;
+        JSONObject publicKeys = apiKeys.getJSONObject("public");
+        JSONObject result = new JSONObject();
+        JSONObject keys = new JSONObject();
+
+        for (String key : JSONObject.getNames(publicKeys)) {
+            JSONObject values =  (JSONObject)publicKeys.get(key);
+            keys.put(key, values.get("value"));
+        }
+
+        try {
+            result.put("accepted", true);
+            result.put("keys", keys);
+            result.put("message", "Success : Fetched all API key successfully !");
+            return new ServiceResponse(result);
+        } catch (Exception e) {
+            throw new APIException(422, "Failed : Unable to fetch API keys!" );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1088 

Changes: Implement API to fetch API keys

endpoint : `/aaa/getApiKeys.json`

Screenshots for the change: 
```
{
  "keys": {
    "MAP_KEY": "AIzaSyCWxXuqny-dx-1FiMrjCSr6fFvukoy7oEM",
    "BLOG_KEY": "qsmzjtyycc49whsfvf5ikzottxrbditq3burojhd",
    "CAPTCHA_KEY": "6LfPZGAUAAAAANY4ZLR_lSat_YCuqqcV3sl84ulW"
  },
  "session": {"identity": {
    "type": "host",
    "name": "127.0.0.1_80ec74be",
    "anonymous": true
  }},
  "accepted": true,
  "message": "Success : Fetched all API key successfully !"
}
```