### PR TITLE
Update chatbot.json in modifying private skills

### DIFF
--- a/src/ai/susi/DAO.java
+++ b/src/ai/susi/DAO.java
@@ -651,36 +651,66 @@ public class DAO {
             throw new IOException (e.getMessage());
         }
     }
-    
     public static Thread addAndPushCommit(String commit_message, String userEmail, boolean concurrently) {
-    	Runnable process = new Runnable() {
-			@Override
-			public void run() {
-				try (Git git = getGit()) {
-		            long t0 = System.currentTimeMillis();
-		            git.add().setUpdate(true).addFilepattern(".").call();
-		            long t1 = System.currentTimeMillis();
-		            git.add().addFilepattern(".").call(); // takes long 
-		            long t2 = System.currentTimeMillis();
-		            
-		            // commit the changes
-		            DAO.pushCommit(git, commit_message, userEmail); // takes long
-		            long t3 = System.currentTimeMillis();
-		            DAO.log("jgit statistics: add-1: " + (t1 - t0) + "ms, add-2: " + (t2 - t1) + "ms, push: " + (t3 - t2) + "ms");
-		        } catch (IOException | GitAPIException e) {
-		            e.printStackTrace();
+      Runnable process = new Runnable() {
+        @Override
+        public void run() {
+          try (Git git = getGit()) {
+            long t0 = System.currentTimeMillis();
+            git.add().setUpdate(true).addFilepattern(".").call();
+            long t1 = System.currentTimeMillis();
+            git.add().addFilepattern(".").call(); // takes long
+            long t2 = System.currentTimeMillis();
 
-		        }
-			}
-    	};
-    	if (concurrently) {
-    		Thread t = new Thread(process);
-    		t.start();
-    		return t;
-    	} else {
-    		process.run();
-    		return null;
-    	}
+            // commit the changes
+            DAO.pushCommit(git, commit_message, userEmail); // takes long
+            long t3 = System.currentTimeMillis();
+            DAO.log("jgit statistics: add-1: " + (t1 - t0) + "ms, add-2: " + (t2 - t1) + "ms, push: " + (t3 - t2) + "ms");
+          } catch (IOException | GitAPIException e) {
+            e.printStackTrace();
+
+          }
+        }
+      };
+      if (concurrently) {
+        Thread t = new Thread(process);
+        t.start();
+        return t;
+      } else {
+        process.run();
+        return null;
+      }
+    }
+
+    public static Thread addAndPushCommitPrivate(String commit_message, String userEmail, boolean concurrently) {
+      Runnable process = new Runnable() {
+        @Override
+        public void run() {
+          try (Git git = getPrivateGit()) {
+            long t0 = System.currentTimeMillis();
+            git.add().setUpdate(true).addFilepattern(".").call();
+            long t1 = System.currentTimeMillis();
+            git.add().addFilepattern(".").call(); // takes long
+            long t2 = System.currentTimeMillis();
+
+            // commit the changes
+            DAO.pushCommit(git, commit_message, userEmail); // takes long
+            long t3 = System.currentTimeMillis();
+            DAO.log("jgit statistics: add-1: " + (t1 - t0) + "ms, add-2: " + (t2 - t1) + "ms, push: " + (t3 - t2) + "ms");
+          } catch (IOException | GitAPIException e) {
+            e.printStackTrace();
+
+          }
+        }
+      };
+      if (concurrently) {
+        Thread t = new Thread(process);
+        t.start();
+        return t;
+      } else {
+        process.run();
+        return null;
+      }
     }
 
     /**


### PR DESCRIPTION
Fixes #1094 

Changes: 
- In `ModifySkillService.java`, modify the data in `chatbot.json` file too, according to the new data provided. This involves deleting the old entry and creating a new one.
- In `DAO.java` make a new method `addAndPushCommitPrivate` to add and commit to private skill data folder, similar to how `addAndPushCommit` method does for public skills.

Screenshots for the change: 
*Before modifying the skill:*
![image](https://user-images.githubusercontent.com/17807257/43473438-c10ebc8c-950d-11e8-9365-1e82bc424419.png)
*After modifying the skill, the new data successfully got saved in `chatbot.json` file, and being reflected in the `getSkillMetadata.json` API.*
![image](https://user-images.githubusercontent.com/17807257/43473481-e5a74f3c-950d-11e8-93fb-7895692346dc.png)

