### PR TITLE
Allow private skill to be used only through configured domains

### DIFF
--- a/src/ai/susi/DAO.java
+++ b/src/ai/susi/DAO.java
@@ -496,6 +496,34 @@ public class DAO {
         return config.keySet();
     }
 
+    /**
+    * Checks if the client's domain is allowed by the bot creator
+    * @param configureObject
+    * @param @referer
+    */
+    public static boolean allowDomainForChatbot(JSONObject configureObject, String referer) {
+        Boolean allowed_site = true;
+        if (configureObject.getBoolean("allow_bot_only_on_own_sites") && configureObject.has("allowed_sites") && configureObject.getString("allowed_sites").length() > 0) {
+            allowed_site = false;
+            if (referer != null && referer.length() > 0) {
+                String[] sites = configureObject.getString("allowed_sites").split(",");
+                for (int i = 0; i < sites.length; i++) {
+                    String site = sites[i].trim();
+                    int referer_index = referer.indexOf("://");
+                    String host = referer;
+                    if (referer.indexOf('/',referer_index+3) > -1) {
+                        host = referer.substring(0,referer.indexOf('/',referer_index+3));
+                    }
+                    if (host.equalsIgnoreCase(site)) {
+                        allowed_site = true;
+                        break;
+                    }
+                }
+            }
+        }
+        return allowed_site; 
+    }
+
     public static final Random random = new Random(System.currentTimeMillis());
 
     public static void log(String line) {

--- a/src/ai/susi/server/api/susi/SusiService.java
+++ b/src/ai/susi/server/api/susi/SusiService.java
@@ -40,6 +40,7 @@ import ai.susi.json.JsonTray;
 import org.json.JSONTokener;
 
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletRequest;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -182,8 +183,18 @@ public class SusiService extends AbstractAPIHandler implements APIHandler {
                         languageName = groupName.getJSONObject(language);
                         if (languageName.has(skill_name)) {
                             skillName = languageName.getJSONObject(skill_name);
-                            if (skillName.getJSONObject("configure").getBoolean("enable_default_skills") == false) {
+                            Boolean allowed_site = true;
+                            JSONObject configureName = skillName.getJSONObject("configure");
+                            if (configureName.getBoolean("enable_default_skills") == false) {
                                 include_default_skills = false;
+                            }
+                            HttpServletRequest request = post.getRequest();
+                            String referer = request.getHeader("Referer");
+                            if (DAO.allowDomainForChatbot(configureName, referer) == false) {
+                                JSONObject json = new JSONObject(true);
+                                json.put("accepted", false);
+                                json.put("message", "Not allowed to use on this domain");
+                                return new ServiceResponse(json);
                             }
                         }
                     }


### PR DESCRIPTION
Fixes #1112 

Changes: 
- In `GetSkillMetaDataService.java` check if the bot creator has selected `allow_bot_only_on_own_sites` option. If `false`, then the API will work from any domain. If `true`, then send response only if the requesting site's domain is included in the `allowed_sites` list. The domain is extracted from the `Referer` field of the request header.
- Similarly in `SusiService.java`, send response only if the the current site is allowed by the bot creator.

These checks are only for the private skills. For other public skills / personas, it will work as usual.

Screenshot for the change:
*Not allowed from other domains:*
(For `getSkillMetaData.json` API)
![image](https://user-images.githubusercontent.com/17807257/43837567-85b0b29c-9b36-11e8-84dc-d510dd8d151e.png)
(For `chat.json` API)
![image](https://user-images.githubusercontent.com/17807257/43837827-5755569a-9b37-11e8-9adb-0ca080a6b09b.png)


*Allowed on approved domains:*
(For `getSkillMetaData.json` API)
![image](https://user-images.githubusercontent.com/17807257/43837768-2bb28990-9b37-11e8-9d43-5336872b6a8c.png)
(For `chat.json` API)
![image](https://user-images.githubusercontent.com/17807257/43837850-69b7b896-9b37-11e8-9a62-658d0a41674c.png)

