### PR TITLE
Modified ChangeSkillStatusService to allow Admins and higher user roles to mark any skill as System Skill

### DIFF
--- a/src/ai/susi/server/api/cms/ChangeSkillStatusService.java
+++ b/src/ai/susi/server/api/cms/ChangeSkillStatusService.java
@@ -61,6 +61,7 @@ public class ChangeSkillStatusService extends AbstractAPIHandler implements APIH
         String reviewed = call.get("reviewed", null);
         String editable = call.get("editable", null);
         String staffPick = call.get("staffPick", null);
+        String systemSkill = call.get("systemSkill", null);
 
         if (authorization.getIdentity() == null) {
             throw new APIException(422, "Bad access token.");
@@ -77,6 +78,9 @@ public class ChangeSkillStatusService extends AbstractAPIHandler implements APIH
         else if (staffPick != null && !(staffPick.equals("true") || staffPick.equals("false"))) {
             throw new APIException(400, "Bad service call, invalid arguments.");
         }
+        else if (systemSkill != null && !(systemSkill.equals("true") || systemSkill.equals("false"))) {
+            throw new APIException(400, "Bad service call, invalid arguments.");
+        }
 
         JSONObject result = new JSONObject();
         JsonTray skillStatus = DAO.skillStatus;
@@ -85,7 +89,7 @@ public class ChangeSkillStatusService extends AbstractAPIHandler implements APIH
         JSONObject languageName = new JSONObject();
         JSONObject skillName = new JSONObject();
 
-        if( (reviewed != null && reviewed.equals("true")) || (editable != null && editable.equals("false")) || (staffPick != null && staffPick.equals("true")) ) {
+        if( (reviewed != null && reviewed.equals("true")) || (editable != null && editable.equals("false")) || (staffPick != null && staffPick.equals("true")) || (systemSkill != null && systemSkill.equals("true"))) {
             JSONObject skill_status = new JSONObject();
             if(reviewed != null && reviewed.equals("true")) {
                 skill_status.put("reviewed", true);
@@ -95,6 +99,9 @@ public class ChangeSkillStatusService extends AbstractAPIHandler implements APIH
             }
             if(staffPick != null && staffPick.equals("true")) {
                 skill_status.put("staffPick", true);
+            }
+            if(systemSkill != null && systemSkill.equals("true")) {
+                skill_status.put("systemSkill", true);
             }
             if (skillStatus.has(model_name)) {
                 modelName = skillStatus.getJSONObject(model_name);
@@ -126,6 +133,14 @@ public class ChangeSkillStatusService extends AbstractAPIHandler implements APIH
                             else if(staffPick != null && staffPick.equals("false")) {
                                 skillName.remove("staffPick");
                             }
+
+                            if(systemSkill != null && systemSkill.equals("true")) {
+                                skillName.put("systemSkill", true);
+                            }
+                            else if(systemSkill != null && systemSkill.equals("false")) {
+                                skillName.remove("systemSkill");
+                            }
+
                             skillStatus.commit();
                             result.put("accepted", true);
                             result.put("message", "Skill status changed successfully.");
@@ -160,6 +175,9 @@ public class ChangeSkillStatusService extends AbstractAPIHandler implements APIH
                             }
                             if(staffPick != null && staffPick.equals("false")) {
                                 skillName.remove("staffPick");
+                            }
+                            if(systemSkill != null && systemSkill.equals("false")) {
+                                skillName.remove("systemSkill");
                             }
                             if(skillName.length() == 0) {
                                 languageName.remove(skill_name);


### PR DESCRIPTION
Fixes #1135 

Changes: Modified `/cms/changeSkillStatus.json` to allow Admin and higher user roles to mark any skill as `System Skill`.

For example, the following API call `http://127.0.0.1:4000/cms/changeSkillStatus.json?model=general&group=Knowledge&language=en&skill=acronyms&systemSkill=true&access_token=MpSUjzQ01qDhOfOIZ5NLiBxB4GfEpm` adds the skill `acronyms` to the list of System Skills in the `skillStatus.json` file. The JSON response of this API call is:

```
{
  "session": {"identity": {
    "type": "email",
    "name": "akjn11@gmail.com",
    "anonymous": false
  }},
  "accepted": true,
  "message": "Skill status changed successfully."
}
```

This is also reflected in the skill metadata of the Skill `acronyms` where `staffPick` is set to `true`. The API call `http://localhost:4000/cms/getSkillMetadata.json?model=general&group=Knowledge&language=en&skill=acronyms` gives the following JSON output:

```
{
  "skill_metadata": {
    "model": "general",
    "group": "Knowledge",
    "language": "en",
    "developer_privacy_policy": null,
    "descriptions": "Tells us about acronyms. An abbreviation formed from the initial letters of other words and pronounced as a word",
    "image": "images/acronyms.png",
    "author": "Madhav Rathi",
    "author_url": "https://www.github.com/madhavrathi",
    "author_email": null,
    "skill_name": "Acronyms",
    "protected": false,
    "reviewed": true,
    "editable": false,
    "staffPick": true,
    "systemSkill": true,
    "terms_of_use": null,
    "dynamic_content": true,
    "examples": ["Acronym of NASA"],
    "skill_rating": {
      "negative": "0",
      "bookmark_count": 0,
      "positive": "0",
      "stars": {
        "one_star": 0,
        "four_star": 0,
        "five_star": 0,
        "total_star": 0,
        "three_star": 0,
        "avg_star": 0,
        "two_star": 0
      },
      "feedback_count": 0
    },
    "usage_count": 0,
    "skill_tag": "acronyms",
    "creationTime": "2018-06-28T04:31:15Z",
    "lastAccessTime": "2018-07-26T09:35:54Z",
    "lastModifiedTime": "2018-06-28T04:31:15Z"
  },
  "accepted": true,
  "message": "Success: Fetched Skill's Metadata",
  "session": {"identity": {
    "type": "host",
    "name": "0:0:0:0:0:0:0:1_d94a4646",
    "anonymous": true
  }}
}
```

I've also modified it in a way to allow combined calls like: 
`http://127.0.0.1:4000/cms/changeSkillStatus.json?model=general&group=Knowledge&language=en&skill=acronyms&reviewed=true&editable=false&staffPick=true&systemSkill=true&access_token=zdasIagg71JK9SB7u060ZxrRdHeFAx`. 
This would allow changing the review status, edit status, staff pick status and also the system skill status of a Skill in the same API call.