### PR TITLE
Add parameter to exclude default skills in chat API

### DIFF
--- a/src/ai/susi/server/api/susi/SusiService.java
+++ b/src/ai/susi/server/api/susi/SusiService.java
@@ -88,7 +88,12 @@ public class SusiService extends AbstractAPIHandler implements APIHandler {
         String userId = post.get("userid", "");
         String group_name = post.get("group", "");
         String skill_name = post.get("skill", "");
-        Boolean include_default_skills = true;
+        String excludeDefaultSkills = post.get("excludeDefaultSkills","");
+        Boolean exclude_default_skills = false; // if this is true, default skills would be excluded
+
+        if (excludeDefaultSkills.equalsIgnoreCase("true")) {
+            exclude_default_skills = true;
+        }
 
         try {
             DAO.susi.observe(); // get a database update
@@ -186,7 +191,7 @@ public class SusiService extends AbstractAPIHandler implements APIHandler {
                             Boolean allowed_site = true;
                             JSONObject configureName = skillName.getJSONObject("configure");
                             if (configureName.getBoolean("enable_default_skills") == false) {
-                                include_default_skills = false;
+                                exclude_default_skills = true;
                             }
                             HttpServletRequest request = post.getRequest();
                             String referer = request.getHeader("Referer");
@@ -220,7 +225,7 @@ public class SusiService extends AbstractAPIHandler implements APIHandler {
                 e.printStackTrace();
             }
         }
-        if (include_default_skills == true) {
+        if (exclude_default_skills == false) {
             // finally add the general mind definition. It's there if no other mind is conscious or the other minds do not find an answer.
             minds.add(DAO.susi);
         }


### PR DESCRIPTION
Fixes #1145 

Changes: 
- If the client provides the parameter `excludeDefaultSkills` with the value `true`, then don't include default SUSI skills.  Any other case (not providing this parameter or any giving any value other than `true`) will result in including default SUSI skills.

Screenshots for the change: 
For API: `http://localhost:4000/susi/chat.json?q=yo&instant=hi\nhi%20there&excludeDefaultSkills=true`, default susi skills are not applied.
![image](https://user-images.githubusercontent.com/17807257/44355420-3091a300-a4ca-11e8-9d35-2c7a923e3ef5.png)

For API: `http://localhost:4000/susi/chat.json?q=yo&instant=hi\nhi%20there`, default susi skills are applied.
![image](https://user-images.githubusercontent.com/17807257/44355328-f0322500-a4c9-11e8-8f25-9816da6f7af4.png)

