### PR TITLE
Fixes #1171: .vscode is not present in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ dist
 dist/loklak.jar
 /build/
 /.gradle/
-
+.vscode/
 /docs/_build
 
 data/settings/groups.json


### PR DESCRIPTION
Fixes #1171 

Changes: Added .vscode into `.gitignore`.

Screenshots for the change: 
