### PR TITLE
Fix: Make swagger-ui working again

### DIFF
--- a/apidocs/index.html
+++ b/apidocs/index.html
@@ -74,7 +74,7 @@ window.onload = function() {
   
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "http://api.susi.ai/docs/swagger.json",
+    url: "https://api.susi.ai/docs/swagger.json",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
Changes: Swagger was used on gh-pages but it was broken due to CORS header. I have added CORS proxy to make the request complete and make Swagger working again :slightly_smiling_face:

Screenshots for the change: 
![screenshot from 2018-12-03 12-50-47](https://user-images.githubusercontent.com/26259547/49358813-189d0280-f6fa-11e8-9807-ae541439649b.png)

After the PR is merged and the gh-pages is updated at dev.susi.ai.

The Swagger docs would be able to previewed at https://dev.susi.ai/apidocs/ which is currently broken.

After updation we can update the links in readme for new devs to be redirected at the above link for better understading of the API.

For Testing how will it work

- Go to http://illustrious-bucket.surge.sh/
- Input this url in input box `https://cors.io/?https://api.susi.ai/docs/swagger.json`
- It will serve the doc using the hosted susi-server

@Orbiter @dynamitechetan @akshatnitd Please review

Thanks!