### PR TITLE
Bugfix: Fix CORS header issue to generate Swagger documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
   compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.+'
   compile group: 'org.apache.httpcomponents', name: 'httpcore', version: '4.+'
   compile group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.+'
+  compile group: 'org.eclipse.jetty', name: 'jetty-servlets', version: '9.3.+'
   compile group: 'com.sun.mail', name: 'javax.mail', version: '1.+'
   compile group: 'org.eclipse.jetty', name: 'jetty-rewrite', version: '9.3.+'
   compile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.3.+'

--- a/src/ai/susi/SusiServer.java
+++ b/src/ai/susi/SusiServer.java
@@ -35,12 +35,9 @@ import java.security.PrivateKey;
 import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 
+import javax.servlet.DispatcherType;
 import javax.servlet.Servlet;
 
 import ai.susi.server.api.aaa.*;
@@ -64,6 +61,8 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.*;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.server.session.HashSessionIdManager;
@@ -682,6 +681,13 @@ public class SusiServer {
         ServletHolder holder = new ServletHolder(sc);
 
         servletHandler.addServlet(holder, "/docs/*");
+
+        FilterHolder cors = servletHandler.addFilter(CrossOriginFilter.class,"/*", EnumSet.of(DispatcherType.REQUEST));
+        cors.setInitParameter(CrossOriginFilter.ALLOWED_ORIGINS_PARAM, "*");
+        cors.setInitParameter(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "*");
+        cors.setInitParameter(CrossOriginFilter.ALLOWED_METHODS_PARAM, "GET,POST,HEAD");
+        cors.setInitParameter(CrossOriginFilter.ALLOWED_HEADERS_PARAM, "X-Requested-With,Content-Type,Accept,Origin");
+
         handlerCollection.addHandler(contexts);
         multipartConfigInjectionHandler.setHandler(handlerCollection);
         SusiServer.server.setHandler(multipartConfigInjectionHandler);


### PR DESCRIPTION
Changes: This PR fixes the CORS issue in Susi Server

I have added `jetty-servlets` module which has CrossOriginFilter class which allows enabling cors on the server.

I have removed unnecessary imports at the beginning of the file too while making the PR.

Screenshots for the change: 
![screenshot from 2018-12-04 20-41-04](https://user-images.githubusercontent.com/26259547/49451368-0f4c8c80-f805-11e8-8f5d-45f250cbe874.png)

Screenshot shows swagger working with locally running server.

For testing the PR:
- Clone the changes
- Run the server 
- Go to http://illustrious-bucket.surge.sh/
- Type `http://localhost:4000/docs/swagger.json` in the input box
- Click on `Explore`

It will work and show no CORS error in console.

@Orbiter Please Review