### PR TITLE
Fixes:#1235 render correct messages and  exceptions

### DIFF
--- a/src/ai/susi/server/api/aaa/PasswordChangeService.java
+++ b/src/ai/susi/server/api/aaa/PasswordChangeService.java
@@ -23,6 +23,9 @@ import ai.susi.tools.TimeoutMatcher;
 import org.json.JSONObject;
 
 import javax.servlet.http.HttpServletResponse;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.regex.Pattern;
 
 /**
@@ -113,18 +116,36 @@ public class PasswordChangeService extends AbstractAPIHandler implements APIHand
                 DAO.log("password change for user: " + identity.getName() + " via newpassword from host: " + post.getClientHost());
 
                 String subject = "Password Change";
+                InetAddress address = null;
+				try {
+					address = InetAddress.getLocalHost();
+				} catch (UnknownHostException e1) {
+					
+				}
+                String findIP = address.getHostAddress();
+                String IP = "127.0.1.1";
                 try {
                     EmailHandler.sendEmail(authentication.getIdentity().getName(), subject, "Your password has been changed successfully!");
                     result.put("message", "Your password has been changed!");
                     result.put("accepted", true);
                 } catch (Exception e) {
-                    throw new APIException(500, "Failed to change password");
+                    if(findIP.equals(IP)) {
+                    	String prepasswordHash = passwordHash;
+                    	String postpasswordHash = authentication.getString("passwordHash");
+                    	if(!prepasswordHash.equals(postpasswordHash)) {
+                    	result.put("message","Your password has sucessfully been changed and stored in the local database!");
+                    	result.put("accepted",true);
+                    	}
+                    	else {
+                    		throw new APIException(500,"Failed to update password in the local database!");
+                    	}
                 }
-            }
+                    else{
+                    	throw new APIException(500, "Failed to change password");}
+                    }
+                }
         }
 
         return new ServiceResponse(result);
     }
-
 }
-


### PR DESCRIPTION
Fixes #1235 
Changes: A revamped solution where there is also the inclusion of an "Exception" which gives an error message if in case the local server is not able to update the password due to a "Server error".
Screenshots for the change: 
