### PR TITLE
add skill_repo.enable configuration variable disabling git access

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -110,6 +110,9 @@ etherpad.urlstub = http://dream.susi.ai
 github.username = username
 github.password = password
 
+# the skill repository can be updated regularly, as well as pushing updates
+# upstream. To disable this behavior , set the following variable to false.
+skill_repo.enable = true
 #To pull skill data timer in milliseconds
 skill_repo.pull_delay = 60000
 skill_repo.admin_email = server@loklak.org

--- a/src/ai/susi/DAO.java
+++ b/src/ai/susi/DAO.java
@@ -444,9 +444,10 @@ public class DAO {
         access = new AccessTracker(log_dump_dir.toFile(), ACCESS_DUMP_FILE_PREFIX, 60000, 3000);
         access.start(); // start monitor
 
-        log("Starting Skill Data pull thread");
-        SkillTransactions.init(getConfig("skill_repo.pull_delay", 60000));
-
+        if (getConfig("skill_repo.enable", true)) {
+                log("Starting Skill Data pull thread");
+                SkillTransactions.init(getConfig("skill_repo.pull_delay", 60000));
+        }
         log("finished DAO initialization");
     }
 


### PR DESCRIPTION
Having a thread running to pull/push skill data from/to the main git repo is in some circumstances
not preferable. Add a configuration option to disable this behavior (but default to true to keep current
behavior).