### PR TITLE
fix uncaught exception on empty response

### DIFF
--- a/src/ai/susi/mind/SusiInference.java
+++ b/src/ai/susi/mind/SusiInference.java
@@ -19,6 +19,7 @@
 
 package ai.susi.mind;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.regex.Matcher;
@@ -293,8 +294,16 @@ public class SusiInference {
                 if (definition.has("url") && definition.has("path")) try {
                     String url = flow.unify(definition.getString("url"), true, Integer.MAX_VALUE);
                     String path = flow.unify(definition.getString("path"), false, Integer.MAX_VALUE);
-                    byte[] b = ConsoleService.loadData(url);
-                    JSONArray data = JsonPath.parse(b, path);
+                    byte[] b;
+                    JSONArray data;
+                    try {
+                        b = ConsoleService.loadData(url);
+                        data = JsonPath.parse(b, path);
+                    } catch (IOException e) {
+                        DAO.log("no response from API " + url);
+                        data = null;
+                    }
+
                     if (data != null) {
                         JSONArray learned = new SusiTransfer("*").conclude(data);
                         if (learned.length() > 0 && definition.has("actions") &&


### PR DESCRIPTION
loading data from a remote API uses HttpClient.load, which might throw
an IOException "no content available for url " + source_url

2019-03-17 11:01:54.353 WARN root  - SusiInference.applyProcedures
java.io.IOException: no content available for url https://api.wolframalpha.com/v2/query?input=describe+4+time+9&output=JSON&appid=9WA6XR-26EWTGEVTE
	at ai.susi.tools.HttpClient.load(HttpClient.java:536)
	at ai.susi.server.api.susi.ConsoleService.loadData(ConsoleService.java:106)
	at ai.susi.mind.SusiInference.applyProcedures(SusiInference.java:296)
	at ai.susi.mind.SusiIntent.consideration(SusiIntent.java:788)
	at ai.susi.mind.SusiMind.react(SusiMind.java:460)
	at ai.susi.mind.SusiMind.reactMinds(SusiMind.java:514)
	at ai.susi.mind.SusiCognition.<init>(SusiCognition.java:119)
	at ai.susi.server.api.susi.SusiService.serviceImpl(SusiService.java:263)
	at ai.susi.server.api.susi.SusiService.serviceImpl(SusiService.java:75)
	at ai.susi.server.AbstractAPIHandler.process(AbstractAPIHandler.java:138)
	at ai.susi.server.AbstractAPIHandler.doGet(AbstractAPIHandler.java:78)

This exception is nowhere caught.
One possible place would be ConsoleService.loadData, but since the
return value of this function is expected to already contain a certain
json format response, returning an empty response or "{}" here does not
work.
The next level SusiInference.applyProcedure. Add a try/catch there
and log that no answer was received.