### PR TITLE
allow for logging to stdout while still daemonizing

### DIFF
--- a/systemd/ss-susi-server.service.in
+++ b/systemd/ss-susi-server.service.in
@@ -3,8 +3,9 @@ Description=Starting SUSI Server for SUSI Linux
 
 [Service]
 User=@SUSI_SERVER_USER@
-# Tell SUSI server not to run as daemon, so that systemd can manage it better
-Environment=DO_NOT_DAEMONIZE=1
+Type=forking
+PIDFile=@INSTALL_DIR@/data/susi.pid
+Environment=SS_LOG_TO_STDOUT=1
 ExecStart=@INSTALL_DIR@/bin/start.sh
 
 [Install]


### PR DESCRIPTION
In the systemd service unit we want the daemon be of type
forking, so that systemd can reliable determine whether startup
has completed.

We add a setting SS_LOG_TO_STDOUT (cmd line option -o) to start.sh
that triggers this.

For the systemd unit we set the above env variable to 1, set
the type to forking, and in addition specify for stability the
location of the PID file.