### PR TITLE
Add missing keys in changeUserSettings #1263

### DIFF
--- a/src/ai/susi/server/api/aaa/ChangeUserSettings.java
+++ b/src/ai/susi/server/api/aaa/ChangeUserSettings.java
@@ -51,7 +51,7 @@ public class ChangeUserSettings extends AbstractAPIHandler implements APIHandler
 
     private static final long serialVersionUID = -7418883159709458190L;
 
-    private String[] possibleKeys = {"server","enterAsSend","micInput", "speechOutput", "speechOutputAlways", "speechRate", "ttsLanguage", "userName", "prefLanguage", "timeZone", "countryCode", "countryDialCode", "phoneNo", "checked", "serverUrl", "theme", "previewTheme"};
+    private String[] possibleKeys = {"server", "enterAsSend", "micInput", "speechOutput", "speechOutputAlways", "speechRate", "ttsLanguage", "userName", "prefLanguage", "timeZone", "countryCode", "countryDialCode", "phoneNo", "checked", "serverUrl", "theme", "backgroundImage", "messageBackgroundImage", "customThemeValue", "avatarType"};
 
     @GET
     @ApiOperation(httpMethod = "GET", value = "Resource to write user setting")


### PR DESCRIPTION
Fixes #1263 

Changes: Left customThemeValue, avatar by mistake in https://github.com/fossasia/susi_server/pull/1261

Currently, backgroundImage uses 2 images with comma separated, backgroundImage: 'backgroundImage, messageBackgroundImage', use 2 fields instead.

