### PR TITLE
add music shuffle intent

### DIFF
--- a/conf/os_skills/operation/en/en_0001_foundation.txt
+++ b/conf/os_skills/operation/en/en_0001_foundation.txt
@@ -93,6 +93,11 @@ start over | restart | start again
 {"actions":[{"type":"restart"}]}
 eol
 
+shuffle | shuffle playlist | shuffle songs
+!console:
+{"actions":[{"type":"shuffle"}]}
+eol
+
 # test audio play
 system check
 !console:all systems are go, all lights are green!

--- a/src/ai/susi/mind/SusiAction.java
+++ b/src/ai/susi/mind/SusiAction.java
@@ -85,7 +85,8 @@ public class SusiAction {
         image_show,    // show an image (recorded, asset on client or asset from web)
         emotion,       // show an emotion (either change tone of tts or change visible style)
         button_push,   // push a button (either on the client device or an IoT appliance connected to the client)
-        io             // set an IO status on connected IoT device
+        io,             // set an IO status on connected IoT device
+        shuffle         // shuffle the current playlist
         ;
     
         private final int score;
@@ -165,6 +166,9 @@ public class SusiAction {
                     //next has no attributes
                     break;
                     */
+                case shuffle:
+                    //shuffle has no attributes
+                    break;
                 case table:
                     if (!json.has("columns")) throw new SusiActionException("the table action needs a columns object");
                     if (!json.has("count")) json.put("count", -1);


### PR DESCRIPTION
Fixes: #1270

Changes: 
- Add shuffle media action intent

Screenshots for the change: 
```
    "metadata": {"count": 6},
    "actions": [{"type": "shuffle"}],
    "skills": ["/susi_server/conf/os_skills/operation/en/en_0001_foundation.txt"],
    "persona": {}
```
