### PR TITLE
fix JARFILE name

### DIFF
--- a/bin/preload.sh
+++ b/bin/preload.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-JARFILE="build/libs/susi_server-all.jar"
+JARFILE="build/libs/susi_server.jar"
 INSTALLATIONCONFIG="data/settings/installation.txt"
 PIDFILE="data/susi.pid"
 DFAULTCONFIG="conf/config.properties"


### PR DESCRIPTION
Fixes #1278

Changes: update bin/preload.sh with the correct JARFILE name

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/14289201/59894974-492b5c00-9400-11e9-8356-dccfc9eea843.png)

