### PR TITLE
fix release script to include correct jar, better infos

### DIFF
--- a/bin/preload.sh
+++ b/bin/preload.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 JARFILE="build/libs/susi_server.jar"
+FATJARFILE="build/libs/susi_server-all.jar"
 INSTALLATIONCONFIG="data/settings/installation.txt"
 PIDFILE="data/susi.pid"
 DFAULTCONFIG="conf/config.properties"
@@ -34,10 +35,14 @@ fi
 
 if [ -f $JARFILE ]; then
     CLASSPATH="$JARFILE"
+elif [ -f $FATJARFILE ]; then
+    CLASSPATH="$FATJARFILE"
 else
     echo "It seems you haven't compiled SUSI"
     echo "To build SUSI,"
     echo "$ ./gradlew build"
+    echo "To build a fat jar (all dependencies included),"
+    echo "$ ./gradlew assemble"
     exit 1
 fi
 

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -22,7 +22,7 @@ while getopts ":pb" opt; do
 done
 
 # variables used from preload.sh
-# JARFILE="build/libs/susi_server-all.jar"
+# FATJARFILE="build/libs/susi_server-all.jar"
 
 # make release file name
 GITHASH=`git log -n 1 --pretty=format:"%h"`
@@ -48,7 +48,7 @@ mkdir $RELEASE_PATH/$RELEASE_FILE/systemd
 cp -R conf $RELEASE_PATH/$RELEASE_FILE/
 cp -R html $RELEASE_PATH/$RELEASE_FILE/
 cp bin/*.sh $RELEASE_PATH/$RELEASE_FILE/bin/
-cp $JARFILE $RELEASE_PATH/$RELEASE_FILE/$JARFILE
+cp $FATJARFILE $RELEASE_PATH/$RELEASE_FILE/$FATJARFILE
 cp systemd/* $RELEASE_PATH/$RELEASE_FILE/systemd/
 
 # make a complete copy


### PR DESCRIPTION
With the changes from 21dac499963a1b709eff684512afbb95b9ac065c, the lean
jar file (`susi_server.jar`) is included in the release tarballs, which is a bug, since
we cannot be sure that the necessary modules are installed on the target system,
in particular they are not available on rpi, thus susi_server cannot start there.

This commit changes the following items
- `release.sh` installs the fat jar
- `start.sh` search for availability of first the lean jar and then the fat jar for starting