### PR TITLE
Fix password RegEx #1323

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -14,7 +14,7 @@ users.public.signup=true
 
 # Regular expression for passwords (warning: has to be a valid java string, escape characters need to be double escaped e.g. \\d instead of \d
 # Require user passwords to have atleast 8 characters and atleast one special character, one number and text characters
-users.password.regex=^((?=.*\\d)(?=.*[A-Z])(?=.*\\W).{8,64})$
+users.password.regex=^((?=.*\\d)(?=.*[a-z])(?=.*\\W).{8,64})$
 users.password.regex.tooltip=Enter a combination of atleast 8 characters and atleast one special character, one number and text characters
 
 # Regualar express for username to have 5-51 characters

--- a/src/ai/susi/server/api/aaa/PasswordChangeService.java
+++ b/src/ai/susi/server/api/aaa/PasswordChangeService.java
@@ -93,7 +93,7 @@ public class PasswordChangeService extends AbstractAPIHandler implements APIHand
             result.put("message", "Invalid credentials.");
             throw new APIException(HttpStatus.UNPROCESSABLE_ENTITY_422, "Invalid credentials");
         } else {
-            String passwordPattern = DAO.getConfig("users.password.regex", "^((?=.*\\d)(?=.*[A-Z])(?=.*\\W).{8,64})$");
+            String passwordPattern = DAO.getConfig("users.password.regex", "^((?=.*\\d)(?=.*[a-z])(?=.*\\W).{8,64})$");
 
             Pattern pattern = Pattern.compile(passwordPattern);
 

--- a/src/ai/susi/server/api/aaa/PasswordRecoveryService.java
+++ b/src/ai/susi/server/api/aaa/PasswordRecoveryService.java
@@ -66,7 +66,7 @@ public class PasswordRecoveryService extends AbstractAPIHandler implements APIHa
 				if (DAO.passwordreset.has(credentialcheck.toString())) {
 					Authentication authentication = new Authentication(credentialcheck, DAO.passwordreset);
 					if (authentication.checkExpireTime()) {
-						String passwordPattern = DAO.getConfig("users.password.regex", "^((?=.*\\d)(?=.*[A-Z])(?=.*\\W).{8,64})$");
+						String passwordPattern = DAO.getConfig("users.password.regex", "^((?=.*\\d)(?=.*[a-z])(?=.*\\W).{8,64})$");
 						String passwordPatternTooltip = DAO.getConfig("users.password.regex.tooltip",
 								"Enter a combination of atleast 8 characters and atleast one special character, one number and text characters");
 						result.put("message", "Email ID: " + authentication.getIdentity().getName());

--- a/src/ai/susi/server/api/aaa/PasswordResetService.java
+++ b/src/ai/susi/server/api/aaa/PasswordResetService.java
@@ -63,7 +63,7 @@ public class PasswordResetService extends AbstractAPIHandler implements APIHandl
 		ClientCredential emailcred = new ClientCredential(ClientCredential.Type.passwd_login,
 				authentication.getIdentity().getName());
 
-		String passwordPattern = DAO.getConfig("users.password.regex", "^((?=.*\\d)(?=.*[A-Z])(?=.*\\W).{8,64})$");
+		String passwordPattern = DAO.getConfig("users.password.regex", "^((?=.*\\d)(?=.*[a-z])(?=.*\\W).{8,64})$");
 
 		Pattern pattern = Pattern.compile(passwordPattern);
 

--- a/src/ai/susi/server/api/aaa/SignUpService.java
+++ b/src/ai/susi/server/api/aaa/SignUpService.java
@@ -86,7 +86,7 @@ public class SignUpService extends AbstractAPIHandler implements APIHandler {
 
 		// if regex is requested
 		if (post.get("getParameters", false)) {
-			String passwordPattern = DAO.getConfig("users.password.regex", "^((?=.*\\d)(?=.*[A-Z])(?=.*\\W).{8,64})$");
+			String passwordPattern = DAO.getConfig("users.password.regex", "^((?=.*\\d)(?=.*[a-z])(?=.*\\W).{8,64})$");
 			String passwordPatternTooltip = DAO.getConfig("users.password.regex.tooltip",
 					"Enter a combination of atleast 8 characters and atleast one special character, one number and text characters");
 			if ("false".equals(DAO.getConfig("users.public.signup", "false"))) {
@@ -166,7 +166,7 @@ public class SignUpService extends AbstractAPIHandler implements APIHandler {
 		}
 
 		// check password pattern
-		String passwordPattern = DAO.getConfig("users.password.regex", "^(?=.*\\d).{6,64}$");
+		String passwordPattern = DAO.getConfig("users.password.regex", "^((?=.*\\d)(?=.*[a-z])(?=.*\\W).{8,64})$");
 		String passwordPatternTooltip = DAO.getConfig("users.password.regex.tooltip", "Enter a combination of atleast 8 characters and atleast one special character, one number and text characters");
 		pattern = Pattern.compile(passwordPattern);
 


### PR DESCRIPTION
Fixes #1323

Changes: Currently, password regex requires an upper case letter as well. Require user passwords to have at least 8 characters and at least one special character, one number, and text characters

