### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ matrix:
       # If build successful, deploy to GC using kubernetes
       after_success:
         - 'bash <(curl -s https://codecov.io/bash)'
-        - travis_wait 30 bash kubernetes/travis/deploy.sh
-        - travis_wait 30 bash kubernetes/travis/deploy-master.sh
+        - bash kubernetes/travis/deploy.sh
+        - bash kubernetes/travis/deploy-master.sh
         - bash .utility/push-javadoc-to-gh-pages.sh
       # deploy to heroku
       deploy:


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
