### PR TITLE
Docs: Add Windows setup guide and JDK 8 requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,31 @@ A self-upgrading process is available which must be triggered by a shell command
 
     > bin/upgrade.sh
 
+    ### 🪟 Setup on Windows
+
+**Prerequisites:**
+* **Git Bash** (Recommended terminal)
+* **Java 8 (JDK 1.8)** - *Strictly required. Newer versions will fail.*
+
+**Installation Steps:**
+1.  **Install Java 8:**
+    * Download [Eclipse Temurin JDK 8](https://adoptium.net/temurin/releases/?version=8).
+    * **Important:** During installation, select the feature **"Set JAVA_HOME variable"** (change the Red X to "Will be installed on local hard drive"). This saves you from editing Environment Variables manually.
+    
+2.  **Clone and Build:**
+    ```bash
+    git clone [https://github.com/fossasia/susi_server.git](https://github.com/fossasia/susi_server.git)
+    cd susi_server
+    ./gradlew.bat build -x test
+    ```
+    *(Note: We skip tests `-x test` for the initial build to avoid network timeouts)*
+
+3.  **Run the Server:**
+    ```bash
+    ./gradlew.bat start
+    ```
+    The server will start at `http://localhost:4000`.
+
 *********
 Where can I download ready-built releases of SUSI.AI?
 *********

--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,8 @@ A self-upgrading process is available which must be triggered by a shell command
     
 2.  **Clone and Build:**
     ```bash
-    git clone [https://github.com/fossasia/susi_server.git](https://github.com/fossasia/susi_server.git)
+    git clone [https://github.com/fossasia/susi_server.git]
+             (https://github.com/fossasia/susi_server.git)
     cd susi_server
     ./gradlew.bat build -x test
     ```


### PR DESCRIPTION
**Issue**
The current README lacks specific instructions for Windows users, leading to build failures due to missing `JAVA_HOME` configuration or using incompatible Java versions (JDK 11+).

**Changes**
* Added a dedicated "Setup on Windows" section.
* Explicitly stated the requirement for **JDK 8**.
* Added instructions for enabling `JAVA_HOME` during installation to prevent environment variable errors.
* Documented the correct Gradle command for Windows (`./gradlew.bat`).

## Summary by Sourcery

Document Windows-specific setup requirements and Java version constraints in the README.

Documentation:
- Add a Windows setup section covering environment configuration and build commands.
- State JDK 8 as the required Java version and document JAVA_HOME configuration for Windows installs.
- Document the correct Gradle wrapper command for Windows users.