### PR TITLE
Replace fixed CI waits with Kubernetes rollout-based deployment checks

### DIFF
--- a/kubernetes/travis/deploy.sh
+++ b/kubernetes/travis/deploy.sh
@@ -38,4 +38,26 @@ echo ">>> Pushing docker image"
 docker push fossasia/susi_server
 
 echo ">>> Updating deployment"
-kubectl set image deployment/susi-server --namespace=web susi-server=fossasia/susi_server:$TRAVIS_COMMIT
+kubectl set image deployment/susi-server \ --namespace=web \susi-server=fossasia/susi_server:$TRAVIS_COMMIT
+
+echo ">>> Waiting for Kubernetes rollout to complete"
+
+set -e
+DEPLOYMENT=susi-server
+NAMESPACE=web
+TIMEOUT=300   # seconds
+INTERVAL=5
+
+SECONDS_WAITED=0
+until kubectl rollout status deployment/$DEPLOYMENT -n $NAMESPACE; do
+  sleep $INTERVAL
+  SECONDS_WAITED=$((SECONDS_WAITED + INTERVAL))
+  if [ "$SECONDS_WAITED" -ge "$TIMEOUT" ]; then
+    echo "Rollout timeout exceeded"
+    kubectl get pods -n $NAMESPACE
+    kubectl describe deployment $DEPLOYMENT -n $NAMESPACE
+    exit 1
+  fi
+done
+
+echo "Rollout successful"

--- a/kubernetes/travis/deploy.sh
+++ b/kubernetes/travis/deploy.sh
@@ -38,7 +38,7 @@ echo ">>> Pushing docker image"
 docker push fossasia/susi_server
 
 echo ">>> Updating deployment"
-kubectl set image deployment/susi-server \ --namespace=web \susi-server=fossasia/susi_server:$TRAVIS_COMMIT
+kubectl set image deployment/susi-server --namespace=web susi-server=fossasia/susi_server:$TRAVIS_COMMIT
 
 echo ">>> Waiting for Kubernetes rollout to complete"
 


### PR DESCRIPTION
Fixes #1470

Changes:
- Removed reliance on long static CI waits during deployment.
- Improved deployment logic to rely on Kubernetes readiness instead of fixed time delays.
- Reduced unnecessary CI blocking that caused builds to run for ~30 minutes.

This change prevents Travis builds from being blocked while waiting for resources that are already handled by Kubernetes.

## Summary by Sourcery

Enhancements:
- Add a Kubernetes rollout status wait loop with timeout and diagnostics to the Travis deployment script to avoid long static delays.